### PR TITLE
fix(tagName): fixed an edge-case with decorated component name

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import expect from 'expect';
+import {createRenderer} from 'react-addons-test-utils';
 import reactElementToJSXString from './index';
 
 class TestComponent extends React.Component {}
@@ -253,5 +254,30 @@ describe(`reactElementToJSXString(ReactElement)`, () => {
     expect(
       reactElementToJSXString(<div a={[<div><span /></div>]} />)
     ).toEqual(`<div a={[<div><span /></div>]} />`);
+  });
+
+  it(`reactElementToJSXString(decorator(<span />)`, () => {
+    function myDecorator(ComposedComponent) {
+      class MyDecorator extends React.Component {
+        render() {
+          return (
+            <div>
+              <ComposedComponent {...this.props} />
+            </div>
+          );
+        }
+      }
+      MyDecorator.displayName = ComposedComponent.name + '-Decorated';
+      return MyDecorator;
+    }
+
+    var NestedSpan = myDecorator(<span />);
+    var renderer = createRenderer();
+    renderer.render(<NestedSpan />);
+    expect(
+      reactElementToJSXString(renderer.getRenderOutput())
+    ).toEqual(`<div>
+  <span />
+</div>`);
   });
 });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function toJSXString({ReactElement = null, lvl = 0, inline = false}) {
   } else {
     tagName = ReactElement.type.name ||
       ReactElement.type.displayName ||
+      ReactElement.type.type ||
       ReactElement.type;
   }
 


### PR DESCRIPTION
When decorating components the resulting tagName was `[object Object]`