### PR TITLE
Added test case for Stringifying imported stateless components

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -6,6 +6,8 @@ import React from 'react';
 import expect from 'expect';
 import {createRenderer} from 'react-addons-test-utils';
 import reactElementToJSXString from './index';
+import StatelessComponent from './tests/StatelessComponent';
+import StatelessAnonComponent from './tests/StatelessAnonComponent';
 
 class TestComponent extends React.Component {}
 
@@ -14,6 +16,18 @@ describe(`reactElementToJSXString(ReactElement)`, () => {
     expect(
       reactElementToJSXString(<TestComponent/>)
     ).toEqual(`<TestComponent />`);
+  });
+
+  it(`reactElementToJSXString(<StatelessComponent/>)`, () => {
+    expect(
+      reactElementToJSXString(<StatelessComponent/>)
+      ).toEqual(`<StatelessComponent />`);
+  });
+
+  it(`reactElementToJSXString(<StatelessAnonComponent/>)`, () => {
+    expect(
+      reactElementToJSXString(<StatelessAnonComponent/>)
+      ).toEqual(`<StatelessAnonComponent />`);
   });
 
   it(`reactElementToJSXString(React.createElement('div'))`, () => {

--- a/tests/StatelessAnonComponent.js
+++ b/tests/StatelessAnonComponent.js
@@ -1,0 +1,5 @@
+import React from 'react';
+export default function(props) {
+  let {children} = props;
+  return <div>{children}</div>;
+}

--- a/tests/StatelessComponent.js
+++ b/tests/StatelessComponent.js
@@ -1,0 +1,5 @@
+import React from 'react';
+export default function StatelessComponent(props) {
+  let {children} = props;
+  return <div>{children}</div>;
+}


### PR DESCRIPTION
When exporting a Stateless Component, there are 2 cases.
Case: 1

    export default function(props) {....}

Case:2

    export default function FlexItem(props) {....}

 Generally, we ensure that the Component is named. However, even anonymous functions are valid React stateless components. The test case for case:1 is failing. This only occurs when the components are exported. Otherwise, it works perfectly fine. 