### PR TITLE
Fix <div>{''}</div>

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -417,4 +417,10 @@ describe(`reactElementToJSXString(ReactElement)`, () => {
   123
 </div>`);
   });
+
+  it(`reactElementToJSXString(<div>{''}</div>)`, () => {
+    expect(
+      reactElementToJSXString(<div>{''}</div>)
+    ).toEqual(reactElementToJSXString(<div/>));
+  });
 });

--- a/index.js
+++ b/index.js
@@ -190,5 +190,5 @@ function noChildren(propName) {
 }
 
 function onlyMeaningfulChildren(children) {
-  return children !== true && children !== false && children !== null;
+  return children !== true && children !== false && children !== null && children !== '';
 }


### PR DESCRIPTION
It is not meaningful child and should be filtered.