### PR TITLE
Add displayName option for custom formatting

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -440,4 +440,28 @@ describe(`reactElementToJSXString(ReactElement)`, () => {
   String with 1 js number
 </div>`);
   });
+
+  it(`reactElementToJSXString(<TestComponent />, { displayName: toUpper })`, () => {
+    expect(
+      reactElementToJSXString(<TestComponent />, {
+        displayName: (element) => element.type.name.toUpperCase()
+      })
+    ).toEqual(`<TESTCOMPONENT />`);
+  });
+
+  it(`reactElementToJSXString(<div co={<div a="1" />} />, { displayName: toUpper })`, () => {
+    expect(
+      reactElementToJSXString(<div co={<div a="1" />} />, {
+        displayName: (element) => element.type.toUpperCase()
+      })
+    ).toEqual(`<DIV co={<DIV a="1" />} />`);
+  });
+
+  it(`reactElementToJSXString(<div co={{a: <div a="1" />}} />, { displayName: toUpper })`, () => {
+    expect(
+      reactElementToJSXString(<div co={{a: <div a="1" />}} />, {
+        displayName: (element) => element.type.toUpperCase()
+      })
+    ).toEqual(`<DIV co={{a: <DIV a="1" />}} />`);
+  });
 });

--- a/index.js
+++ b/index.js
@@ -7,85 +7,161 @@ import sortobject from 'sortobject';
 import traverse from 'traverse';
 import fill from 'lodash/array/fill';
 
-export default function reactElementToJSXString(ReactElement, options) {
-  return toJSXString({ReactElement, options});
-}
-
-function toJSXString({ReactElement = null, lvl = 0, inline = false, options = {}}) {
-  if (typeof ReactElement === 'string' || typeof ReactElement === 'number') {
-    return ReactElement;
-  } else if (!isElement(ReactElement)) {
-    throw new Error('react-element-to-jsx-string: Expected a ReactElement, ' +
-      'got `' + (typeof ReactElement) + '`');
-  }
-
+export default function reactElementToJSXString(ReactElement, options = {}) {
   let getDisplayName = options.displayName || getDefaultDisplayName;
-  let tagName = getDisplayName(ReactElement);
 
-  let out = `<${tagName}`;
-  let props = formatProps(ReactElement.props, options);
-  let attributes = [];
-  let children = React.Children.toArray(ReactElement.props.children)
+  return toJSXString({ReactElement});
+
+  function toJSXString({ReactElement: Element = null, lvl = 0, inline = false}) {
+    if (typeof Element === 'string' || typeof Element === 'number') {
+      return Element;
+    } else if (!isElement(Element)) {
+      throw new Error('react-element-to-jsx-string: Expected a ReactElement, ' +
+      'got `' + (typeof Element) + '`');
+    }
+
+    let tagName = getDisplayName(Element);
+
+    let out = `<${tagName}`;
+    let props = formatProps(Element.props);
+    let attributes = [];
+    let children = React.Children.toArray(Element.props.children)
     .filter(onlyMeaningfulChildren);
 
-  if (ReactElement.ref !== null) {
-    attributes.push(getJSXAttribute('ref', ReactElement.ref, options));
-  }
+    if (Element.ref !== null) {
+      attributes.push(getJSXAttribute('ref', Element.ref));
+    }
 
-  if (ReactElement.key !== null &&
+    if (Element.key !== null &&
       // React automatically add key=".X" when there are some children
-      !/^\./.test(ReactElement.key)) {
-    attributes.push(getJSXAttribute('key', ReactElement.key, options));
-  }
-
-  attributes = attributes.concat(props);
-
-  attributes.forEach(attribute => {
-    if (attributes.length === 1 || inline) {
-      out += ` `;
-    } else {
-      out += `\n${spacer(lvl + 1)}`;
+      !/^\./.test(Element.key)) {
+      attributes.push(getJSXAttribute('key', Element.key));
     }
 
-    out += `${attribute.name}=${attribute.value}`;
-  });
+    attributes = attributes.concat(props);
 
-  if (attributes.length > 1 && !inline) {
-    out += `\n${spacer(lvl)}`;
-  }
+    attributes.forEach(attribute => {
+      if (attributes.length === 1 || inline) {
+        out += ` `;
+      } else {
+        out += `\n${spacer(lvl + 1)}`;
+      }
 
-  if (children.length > 0) {
-    out += `>`;
-    lvl++;
-    if (!inline) {
-      out += `\n`;
-      out += spacer(lvl);
+      out += `${attribute.name}=${attribute.value}`;
+    });
+
+    if (attributes.length > 1 && !inline) {
+      out += `\n${spacer(lvl)}`;
     }
 
-    if (typeof children === 'string') {
-      out += children;
-    } else {
-      out += children
+    if (children.length > 0) {
+      out += `>`;
+      lvl++;
+      if (!inline) {
+        out += `\n`;
+        out += spacer(lvl);
+      }
+
+      if (typeof children === 'string') {
+        out += children;
+      } else {
+        out += children
         .reduce(mergePlainStringChildren, [])
         .map(
-          recurse({lvl, inline, options})
+          recurse({lvl, inline})
         ).join('\n' + spacer(lvl));
-    }
-    if (!inline) {
-      out += `\n`;
-      out += spacer(lvl - 1);
-    }
-    out += `</${tagName}>`;
-  } else {
-    if (attributes.length <= 1) {
-      out += ` `;
+      }
+      if (!inline) {
+        out += `\n`;
+        out += spacer(lvl - 1);
+      }
+      out += `</${tagName}>`;
+    } else {
+      if (attributes.length <= 1) {
+        out += ` `;
+      }
+
+      out += '/>';
     }
 
-    out += '/>';
+    return out;
   }
 
-  return out;
+  function formatProps(props) {
+    return Object
+      .keys(props)
+      .filter(noChildren)
+      .sort()
+      .map(propName => {
+        return getJSXAttribute(propName, props[propName]);
+      });
+  }
+
+  function getJSXAttribute(name, value) {
+    return {
+      name,
+      value: formatJSXAttribute(value)
+        .replace(/'?<__reactElementToJSXString__Wrapper__>/g, '')
+        .replace(/<\/__reactElementToJSXString__Wrapper__>'?/g, '')
+    };
+  }
+
+  function formatJSXAttribute(propValue) {
+    if (typeof propValue === 'string') {
+      return `"${propValue}"`;
+    }
+
+    return `{${formatValue(propValue)}}`;
+  }
+
+  function formatValue(value) {
+    if (typeof value === 'function') {
+      return function noRefCheck() {};
+    } else if (isElement(value)) {
+      // we use this delimiter hack in cases where the react element is a property
+      // of an object from a root prop
+      // i.e.
+      //   reactElementToJSXString(<div a={{b: <div />}} />
+      //   // <div a={{b: <div />}} />
+      // we then remove the whole wrapping
+      // otherwise, the element would be surrounded by quotes: <div a={{b: '<div />'}} />
+      return '<__reactElementToJSXString__Wrapper__>' +
+        toJSXString({ReactElement: value, inline: true}) +
+        '</__reactElementToJSXString__Wrapper__>';
+    } else if (isPlainObject(value) || Array.isArray(value)) {
+      return '<__reactElementToJSXString__Wrapper__>' +
+        stringifyObject(value) +
+        '</__reactElementToJSXString__Wrapper__>';
+    }
+
+    return value;
+  }
+
+  function recurse({lvl, inline}) {
+    return Element => {
+      return toJSXString({ReactElement: Element, lvl, inline});
+    };
+  }
+
+  function stringifyObject(obj) {
+    if (Object.keys(obj).length > 0 || obj.length > 0) {
+      obj = traverse(obj).map(function(value) {
+        if (isElement(value) || this.isLeaf) {
+          this.update(formatValue(value));
+        }
+      });
+
+      obj = sortobject(obj);
+    }
+
+    return collapse(stringify(obj))
+      .replace(/{ /g, '{')
+      .replace(/ }/g, '}')
+      .replace(/\[ /g, '[')
+      .replace(/ \]/g, ']');
+  }
 }
+
 
 function getDefaultDisplayName(ReactElement) {
   return ReactElement.type.name || // function name
@@ -109,80 +185,6 @@ function mergePlainStringChildren(prev, cur) {
   }
 
   return prev;
-}
-
-function formatProps(props, options) {
-  return Object
-    .keys(props)
-    .filter(noChildren)
-    .sort()
-    .map(propName => {
-      return getJSXAttribute(propName, props[propName], options);
-    });
-}
-
-function getJSXAttribute(name, value, options) {
-  return {
-    name,
-    value: formatJSXAttribute(value, options)
-      .replace(/'?<__reactElementToJSXString__Wrapper__>/g, '')
-      .replace(/<\/__reactElementToJSXString__Wrapper__>'?/g, '')
-  };
-}
-
-function formatJSXAttribute(propValue, options) {
-  if (typeof propValue === 'string') {
-    return `"${propValue}"`;
-  }
-
-  return `{${formatValue(propValue, options)}}`;
-}
-
-function formatValue(value, options) {
-  if (typeof value === 'function') {
-    return function noRefCheck() {};
-  } else if (isElement(value)) {
-    // we use this delimiter hack in cases where the react element is a property
-    // of an object from a root prop
-    // i.e.
-    //   reactElementToJSXString(<div a={{b: <div />}} />
-    //   // <div a={{b: <div />}} />
-    // we then remove the whole wrapping
-    // otherwise, the element would be surrounded by quotes: <div a={{b: '<div />'}} />
-    return '<__reactElementToJSXString__Wrapper__>' +
-      toJSXString({ReactElement: value, inline: true, options}) +
-      '</__reactElementToJSXString__Wrapper__>';
-  } else if (isPlainObject(value) || Array.isArray(value)) {
-    return '<__reactElementToJSXString__Wrapper__>' +
-      stringifyObject(value, options) +
-      '</__reactElementToJSXString__Wrapper__>';
-  }
-
-  return value;
-}
-
-function recurse({lvl, inline, options}) {
-  return ReactElement => {
-    return toJSXString({ReactElement, lvl, inline, options});
-  };
-}
-
-function stringifyObject(obj, options) {
-  if (Object.keys(obj).length > 0 || obj.length > 0) {
-    obj = traverse(obj).map(function(value) {
-      if (isElement(value) || this.isLeaf) {
-        this.update(formatValue(value, options));
-      }
-    });
-
-    obj = sortobject(obj);
-  }
-
-  return collapse(stringify(obj))
-    .replace(/{ /g, '{')
-    .replace(/ }/g, '}')
-    .replace(/\[ /g, '[')
-    .replace(/ \]/g, ']');
 }
 
 function spacer(times) {


### PR DESCRIPTION
Closes https://github.com/algolia/react-element-to-jsx-string/issues/15

This adds the ability to pass a custom function to format the way components are displayed in the final string.

I've had to pass around the `options` object on all the functions used for recursion. This in my opinion is not very clear, I think it may be better to move the small function under `toJSXString` so that the `options` variable is in scope and can be accessed whenever we recurse again from those functions.

If you agree that's clearer and prefer that approach instead of this current one, let me know and I can modify the PR.