### PR TITLE
allow omitting boolean attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Useful for unit testing and any other need you may think of.
 
 Features:
 - supports nesting and deep nesting like `<div a={{b: {c: {d: <div />}}}} />`
-- props: supports string, number, function (inlined as `prop={function noRefCheck() {}}`), object, ReactElement (inlined), regex..
+- props: supports string, number, function (inlined as `prop={function noRefCheck() {}}`), object, ReactElement (inlined), regex, booleans (with [shorthand syntax](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes)), ...
 - order props alphabetically
 - sort object keys in a deterministic order (`o={{a: 1, b:2}} === o={{b:2, a:1}}`)
 - handle `ref` and `key` attributes, they are always on top of props

--- a/index-test.js
+++ b/index-test.js
@@ -464,4 +464,14 @@ describe(`reactElementToJSXString(ReactElement)`, () => {
       })
     ).toEqual(`<DIV co={{a: <DIV a="1" />}} />`);
   });
+  it('should omit true as value', () => {
+    expect(
+      reactElementToJSXString(<div primary={true} />)  // eslint-disable-line react/jsx-boolean-value
+    ).toEqual(`<div primary />`);
+  });
+  it('should omit attributes with false as value', () => {
+    expect(
+      reactElementToJSXString(<div primary={false} />)  // eslint-disable-line react/jsx-boolean-value
+    ).toEqual(`<div />`);
+  });
 });

--- a/index.js
+++ b/index.js
@@ -47,7 +47,11 @@ export default function reactElementToJSXString(ReactElement, options = {}) {
         out += `\n${spacer(lvl + 1)}`;
       }
 
-      out += `${attribute.name}=${attribute.value}`;
+      if (attribute.value === '{true}') {
+        out += `${attribute.name}`;
+      } else {
+        out += `${attribute.name}=${attribute.value}`;
+      }
     });
 
     if (attributes.length > 1 && !inline) {
@@ -91,6 +95,7 @@ export default function reactElementToJSXString(ReactElement, options = {}) {
     return Object
       .keys(props)
       .filter(noChildren)
+      .filter(prop => noFalse(props[prop]))
       .sort()
       .map(propName => {
         return getJSXAttribute(propName, props[propName]);
@@ -193,6 +198,10 @@ function spacer(times) {
 
 function noChildren(propName) {
   return propName !== 'children';
+}
+
+function noFalse(propValue) {
+  return typeof propValue !== 'boolean' || propValue;
 }
 
 function onlyMeaningfulChildren(children) {


### PR DESCRIPTION
according to https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes it is ok to omit the value of boolean attributes if the value is true. Attributes with value false are unnecessary.

This PR allows (via options: {omitBools: true}) that

```
<Button primary={true}>A Button</Button>
```

becomes

```
<Button primary>A Button</Button>
```

I think this is a good idea in general, but I thought I'll create a option for this, as this is unexpected behavior for existing consumers. What do you think? Should the short syntax be the default?