### PR TITLE
Fix for issue #28

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -465,6 +465,12 @@ describe(`reactElementToJSXString(ReactElement)`, () => {
     ).toEqual(`<DefaultPropsComponent />`);
   });
 
+  it('should render props that differ from their defaults if "showDefaultProps" option is false', () => {
+    expect(
+      reactElementToJSXString(<DefaultPropsComponent test="foo" />, {showDefaultProps: false})
+    ).toEqual(`<DefaultPropsComponent test="foo" />`);
+  });
+
   it(`reactElementToJSXString(<div co={<div a="1" />} />, { displayName: toUpper })`, () => {
     expect(
       reactElementToJSXString(<div co={<div a="1" />} />, {

--- a/index.js
+++ b/index.js
@@ -98,8 +98,8 @@ export default function reactElementToJSXString(ReactElement, {displayName, show
       .filter(key => noFalse(props[key]));
 
     if (!showDefaultProps) {
-      formated = formated.filter((key, value) => {
-        return defaultProps[key] ? defaultProps[key] === value : true;
+      formated = formated.filter(key => {
+        return defaultProps[key] ? defaultProps[key] !== props[key] : true;
       });
     }
 


### PR DESCRIPTION
This fixes an issue that occurs when the `showDefaultProps` option is
`false` but a prop differs from its default value. Previously the prop
would not be rendered at all. Now it will only be omitted if it matches
its default value.