### PR TITLE
change order of where to get the name of a component from

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -18,6 +18,10 @@ class DefaultPropsComponent extends React.Component {}
 
 DefaultPropsComponent.defaultProps = {test: 'test'};
 
+class DisplayNamePrecedence extends React.Component {}
+
+DisplayNamePrecedence.displayName = "This should take precedence";
+
 describe('reactElementToJSXString(ReactElement)', () => {
   it('reactElementToJSXString(<TestComponent/>)', () => {
     expect(
@@ -502,5 +506,11 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual(`<div fn={function fn() {
         return 'value';
       }} />`);
+  });
+
+  it('reactElementToJSXString(DisplayNamePrecedence)', () => {
+    expect(
+      reactElementToJSXString(<DisplayNamePrecedence />)
+      ).toEqual('<This should take precedence />');
   });
 });

--- a/index-test.js
+++ b/index-test.js
@@ -20,7 +20,7 @@ DefaultPropsComponent.defaultProps = {test: 'test'};
 
 class DisplayNamePrecedence extends React.Component {}
 
-DisplayNamePrecedence.displayName = "This should take precedence";
+DisplayNamePrecedence.displayName = 'This should take precedence';
 
 describe('reactElementToJSXString(ReactElement)', () => {
   it('reactElementToJSXString(<TestComponent/>)', () => {

--- a/index.js
+++ b/index.js
@@ -178,8 +178,8 @@ got \`${typeof Element}\``
 
 
 function getDefaultDisplayName(ReactElement) {
-  return ReactElement.type.name || // function name
-    ReactElement.type.displayName ||
+  return ReactElement.type.displayName ||
+    ReactElement.type.name || // function name
     (typeof ReactElement.type === 'function' ? // function without a name, you should provide one
       'No Display Name' :
       ReactElement.type);


### PR DESCRIPTION
Changed the order because `ReactElement.type.name` returns something that doesn't represent the name of the component.

For example if the component was called `Button` it would return a random letter instead like 'L' or 't'.