### PR TITLE
Added configurable option to explicitly output boolean prop values. 

### DIFF
--- a/AnonymousStatelessComponent.js
+++ b/AnonymousStatelessComponent.js
@@ -1,5 +1,5 @@
 import React from 'react';
 export default function(props) {
-  let {children} = props; // eslint-disable-line react/prop-types
+  const {children} = props; // eslint-disable-line react/prop-types
   return <div>{children}</div>;
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Useful for unit testing and any other need you may think of.
 
 Features:
 - supports nesting and deep nesting like `<div a={{b: {c: {d: <div />}}}} />`
-- props: supports string, number, function (inlined as `prop={function noRefCheck() {}}`), object, ReactElement (inlined), regex, booleans (with [shorthand syntax](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes)), ...
+- props: supports string, number, function (inlined as `prop={function noRefCheck() {}}`), object, ReactElement (inlined), regex, booleans (with or without [shorthand syntax](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes)), ...
 - order props alphabetically
 - sort object keys in a deterministic order (`o={{a: 1, b:2}} === o={{b:2, a:1}}`)
 - handle `ref` and `key` attributes, they are always on top of props
@@ -79,6 +79,12 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
   If false, functions bodies are replaced with `function noRefCheck() {}`.
 
+**options.useBooleanShorthandSyntax: boolean, default true**
+
+  If true, Boolean prop values will be omitted for [shorthand syntax](https://facebook.github.io/react/docs/jsx-in-depth.html#boolean-attributes).
+
+  If false, Boolean prop values will be explicitly output like `prop={true}` and `prop={false}`
+  
 ## Test
 
 ```sh

--- a/index-test.js
+++ b/index-test.js
@@ -456,6 +456,18 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual('<TESTCOMPONENT />');
   });
 
+  it('reactElementToJSXString(<TestComponent />, { useBooleanShorthandSyntax: false })', () => {
+    expect(
+      reactElementToJSXString(<TestComponent testTrue={true} testFalse={false} />, {
+        useBooleanShorthandSyntax: false
+      })
+    ).toEqual(
+`<TestComponent
+  testFalse={false}
+  testTrue={true}
+/>`);
+  });
+
   it('should render default props', () => {
     expect(
       reactElementToJSXString(<DefaultPropsComponent />)

--- a/index-test.js
+++ b/index-test.js
@@ -10,7 +10,7 @@ import AnonymousStatelessComponent from './AnonymousStatelessComponent';
 class TestComponent extends React.Component {}
 
 function NamedStatelessComponent(props) {
-  let {children} = props;
+  const {children} = props;
   return <div>{children}</div>;
 }
 

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ export default function reactElementToJSXString(
   ReactElement, {
     displayName,
     showDefaultProps = true,
-    showFunctions = false
+    showFunctions = false,
+    useBooleanShorthandSyntax = true
   } = {}
 ) {
   const getDisplayName = displayName || getDefaultDisplayName;
@@ -55,7 +56,7 @@ got \`${typeof Element}\``
         out += `\n${spacer(lvl + 1)}`;
       }
 
-      if (attribute.value === '{true}') {
+      if (useBooleanShorthandSyntax && attribute.value === '{true}') {
         out += `${attribute.name}`;
       } else {
         out += `${attribute.name}=${attribute.value}`;
@@ -102,8 +103,11 @@ got \`${typeof Element}\``
   function formatProps(props, defaultProps) {
     let formatted = Object
       .keys(props)
-      .filter(noChildren)
-      .filter(key => noFalse(props[key]));
+      .filter(noChildren);
+
+    if (useBooleanShorthandSyntax) {
+      formatted = formatted.filter(key => noFalse(props[key]));
+    }
 
     if (!showDefaultProps) {
       formatted = formatted.filter(key => defaultProps[key] ? defaultProps[key] !== props[key] : true);


### PR DESCRIPTION
For us weird folk that don't use shorthand syntax (I know I know) this adds a configurable option to output boolean values like:

```jsx
<Component prop={true} prop={false} />
```

Default is set to `true` for backwards compatibility ... and also because I imagine the majority use the shorthand syntax. 

_Also there were a couple of eslint errors, not sure if they were there before... I don't think I have any global eslint config madness sneaking in there_
