### PR TITLE
`filterProps` Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
   Just return the name you want for the provided ReactElement, as a string.
 
+**options.filterProps: array, default []**
+
+  Provide an array of props to filter for every component. For example ['key'] will suppress the key="" prop from being added.
+
 **options.showDefaultProps: boolean, default true**
 
   If true, default props shown.

--- a/index-test.js
+++ b/index-test.js
@@ -456,6 +456,14 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual('<TESTCOMPONENT />');
   });
 
+  it('reactElementToJSXString(<TestComponent />, { filterProps: [\'key\', \'className\'] })', () => {
+    expect(
+      reactElementToJSXString(<TestComponent a="b" key="aKey" className="aClass" />, {
+        filterProps: ['key', 'className']
+      })
+    ).toEqual('<TestComponent a="b" />');
+  });
+
   it('reactElementToJSXString(<TestComponent />, { useBooleanShorthandSyntax: false })', () => {
     expect(
       reactElementToJSXString(<TestComponent testTrue={true} testFalse={false} />, {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import {fill} from 'lodash';
 export default function reactElementToJSXString(
   ReactElement, {
     displayName,
+    filterProps = [],
     showDefaultProps = true,
     showFunctions = false,
     useBooleanShorthandSyntax = true
@@ -47,7 +48,9 @@ got \`${typeof Element}\``
       attributes.push(getJSXAttribute('key', Element.key));
     }
 
-    attributes = attributes.concat(props);
+    attributes = attributes
+      .concat(props)
+      .filter(({name}) => filterProps.indexOf(name) === -1);
 
     attributes.forEach(attribute => {
       if (attributes.length === 1 || inline) {


### PR DESCRIPTION
#### showKey
We have situations where we need to add a key property to the input of `reactElementToJsxString` but not to have it printed in the output. This adds a `showKey` option to not print the key prop.

#### lodash
When the import syntax like below is used
```
import {fill} from 'lodash';
``` 
it still requires the whole library, but changing it to 

```
import fill from 'lodash/fill';
```
It will only require that util.

Our build size before this change was `2,428,686 bytes` and afterwards it dropped to `1,898,514 bytes`