### PR TITLE
Added .npmignore file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.babelrc
+.eslintignore
+.eslintrc.js
+.travis.yml
+*.js
+!index-dist.js
+mocha.opts


### PR DESCRIPTION
Removes configs and source code from the published bundle. Fixes #69. This PR is published to NPM under `react-element-to-jsx-string-test` if you want to test it