### PR TITLE
Add maxInlineAttributes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
   If false, Boolean prop values will be explicitly output like `prop={true}` and `prop={false}`
 
-**options.maxInlineAttributes: number, default 1**
+**options.maxInlineAttributesLineLength: number, default undefined**
 
-  Provide the max number of attributes to render inline with the tag name. If the number of attributes exceeds this number, then all attributes will be rendered
-  on a separate line.
+  Provide the max number of characters the render inline with the tag name. If the number of characters exceeds this number, then all attributes will be rendered
+  on a separate line. The default behavior if this option is undefined is render attributes inline if there is only one, and render attributes on multiple
+  lines if there are more than one attribute on the element. Note: Objects passed as attribute values are always rendered on multiple lines
 
 ## Environment requirements
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
 **options.maxInlineAttributesLineLength: number, default undefined**
 
-  Provide the max number of characters to render inline with the tag name. If the number of characters on the line (including spacing and the tag name)
+  Allows to render multiple attributes on the same line and control the behaviour.
+
+  You can provide the max number of characters to render inline with the tag name. If the number of characters on the line (including spacing and the tag name)
   exceeds this number, then all attributes will be rendered on a separate line. The default value of this option is `undefined`. If this option is `undefined`
   then if there is more than one attribute on an element, they will render on their own line. Note: Objects passed as attribute values are always rendered
   on multiple lines

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
   If false, Boolean prop values will be explicitly output like `prop={true}` and `prop={false}`
 
+**options.maxInlineAttributes: number, default 1**
+
+  Provide the max number of attributes to render inline with the tag name. If the number of attributes exceeds this number, then all attributes will be rendered
+  on a separate line.
+
 ## Environment requirements
 
 The environment you use to use `react-element-to-jsx-string` should have [ES2015](https://babeljs.io/learn-es2015/) support.

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
 **options.maxInlineAttributesLineLength: number, default undefined**
 
-  Provide the max number of characters the render inline with the tag name. If the number of characters exceeds this number, then all attributes will be rendered
-  on a separate line. The default behavior if this option is undefined is render attributes inline if there is only one, and render attributes on multiple
-  lines if there are more than one attribute on the element. Note: Objects passed as attribute values are always rendered on multiple lines
+  Provide the max number of characters to render inline with the tag name. If the number of characters on the line (including spacing and the tag name)
+  exceeds this number, then all attributes will be rendered on a separate line. The default value of this option is `undefined`. If this option is `undefined`
+  then if there is more than one attribute on an element, they will render on their own line. Note: Objects passed as attribute values are always rendered
+  on multiple lines
 
 ## Environment requirements
 

--- a/index-test.js
+++ b/index-test.js
@@ -732,4 +732,20 @@ describe('reactElementToJSXString(ReactElement)', () => {
   content
 </div>`);
   });
+
+  // Multi-level inline attribute test
+  it('reactElementToJSXString(<div><div>content</div></div>, { maxInlineAttributesLineLength: 24 }))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2"><div cprop="3" dprop="4">content</div></div>, {
+        maxInlineAttributesLineLength: 24,
+      })
+    ).toEqual(`<div aprop="1" bprop="2">
+  <div
+    cprop="3"
+    dprop="4"
+  >
+    content
+  </div>
+</div>`);
+  });
 });

--- a/index-test.js
+++ b/index-test.js
@@ -654,4 +654,53 @@ describe('reactElementToJSXString(ReactElement)', () => {
       reactElementToJSXString(<DisplayNamePrecedence />)
     ).toEqual('<This should take precedence />');
   });
+
+  // maxInlineAttributes tests
+  it('reactElementToJSXString(<div aprop="1" bprop="2" />, { maxInlineAttributes: 3 }))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2" />, {maxInlineAttributes: 3})
+    ).toEqual('<div aprop="1" bprop="2" />');
+  });
+  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" />, { maxInlineAttributes: 3 }))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" />, {maxInlineAttributes: 3})
+    ).toEqual('<div aprop="1" bprop="2" cprop="3" />');
+  });
+  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4" />, { maxInlineAttributes: 3 }))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4" />, {maxInlineAttributes: 3})
+    ).toEqual(`<div
+  aprop="1"
+  bprop="2"
+  cprop="3"
+  dprop="4"
+/>`);
+  });
+  it('reactElementToJSXString(<div aprop="1" bprop="2">content</div>, { maxInlineAttributes: 3 }))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2">content</div>, {maxInlineAttributes: 3})
+    ).toEqual(`<div aprop="1" bprop="2">
+  content
+</div>`);
+  });
+  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3">content</div>, { maxInlineAttributes: 3 }))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3">content</div>, {maxInlineAttributes: 3})
+    ).toEqual(`<div aprop="1" bprop="2" cprop="3">
+  content
+</div>`);
+  });
+  // eslint-disable-next-line max-len
+  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4">content</div>, {maxInlineAttributes: 3}))', () => {
+    expect(
+      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4">content</div>, {maxInlineAttributes: 3})
+    ).toEqual(`<div
+  aprop="1"
+  bprop="2"
+  cprop="3"
+  dprop="4"
+>
+  content
+</div>`);
+  });
 });

--- a/index-test.js
+++ b/index-test.js
@@ -103,6 +103,28 @@ describe('reactElementToJSXString(ReactElement)', () => {
  />`);
   });
 
+  it('reactElementToJSXString(<div a="1" obj={{hello: \'world\'}}/>)', () => {
+    expect(
+      reactElementToJSXString(<div a="1" obj={{hello: 'world'}}/>)
+    ).toEqual(`<div
+  a="1"
+  obj={{
+    hello: 'world'
+  }}
+/>`);
+  });
+
+  it('reactElementToJSXString(<div obj={{hello: \'world\'}} a="1"/>)', () => {
+    expect(
+      reactElementToJSXString(<div obj={{hello: 'world'}} a="1"/>)
+    ).toEqual(`<div
+  a="1"
+  obj={{
+    hello: 'world'
+  }}
+/>`);
+  });
+
   it('reactElementToJSXString(<div obj={{hello: [1, 2], world: {nested: true}}}/>)', () => {
     expect(
       reactElementToJSXString(<div obj={{hello: [1, 2], world: {nested: true}}}/>)

--- a/index-test.js
+++ b/index-test.js
@@ -677,50 +677,57 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual('<This should take precedence />');
   });
 
-  // maxInlineAttributes tests
-  it('reactElementToJSXString(<div aprop="1" bprop="2" />, { maxInlineAttributes: 3 }))', () => {
+  // maxInlineAttributesLineLength tests
+  // Validate two props will stay inline if their length is less than the option
+  it('reactElementToJSXString(<div aprop="1" bprop="2" />, { maxInlineAttributesLineLength: 100 }))', () => {
     expect(
-      reactElementToJSXString(<div aprop="1" bprop="2" />, {maxInlineAttributes: 3})
+      reactElementToJSXString(<div aprop="1" bprop="2" />, {maxInlineAttributesLineLength: 100})
     ).toEqual('<div aprop="1" bprop="2" />');
   });
-  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" />, { maxInlineAttributes: 3 }))', () => {
+  // Validate one prop will go to new line if length is greater than option. One prop is a special case since
+  // the old logic operated on whether or not two or more attributes were present. Making sure this overrides
+  // that older logic
+  it('reactElementToJSXString(<div aprop="1"/>, { maxInlineAttributesLineLength: 5 }))', () => {
     expect(
-      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" />, {maxInlineAttributes: 3})
-    ).toEqual('<div aprop="1" bprop="2" cprop="3" />');
+      reactElementToJSXString(<div aprop="1"/>, {maxInlineAttributesLineLength: 5})
+    ).toEqual(`<div
+  aprop="1"
+/>`);
   });
-  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4" />, { maxInlineAttributes: 3 }))', () => {
+  // Validate two props will go be multiline if their length is greater than the given option
+  it('reactElementToJSXString(<div aprop="1" bprop="2" />, { maxInlineAttributesLineLength: 10 }))', () => {
     expect(
-      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4" />, {maxInlineAttributes: 3})
+      reactElementToJSXString(<div aprop="1" bprop="2" />, {maxInlineAttributesLineLength: 10})
     ).toEqual(`<div
   aprop="1"
   bprop="2"
-  cprop="3"
-  dprop="4"
 />`);
   });
-  it('reactElementToJSXString(<div aprop="1" bprop="2">content</div>, { maxInlineAttributes: 3 }))', () => {
+
+  // Same tests as above but with elements that have children. The closing braces for elements with children and without children
+  // run through different code paths so we have both sets of test to specify the behavior of both when this option is present
+  it('reactElementToJSXString(<div aprop="1" bprop="2">content</div>, { maxInlineAttributesLineLength: 100 }))', () => {
     expect(
-      reactElementToJSXString(<div aprop="1" bprop="2">content</div>, {maxInlineAttributes: 3})
+      reactElementToJSXString(<div aprop="1" bprop="2">content</div>, {maxInlineAttributesLineLength: 100})
     ).toEqual(`<div aprop="1" bprop="2">
   content
 </div>`);
   });
-  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3">content</div>, { maxInlineAttributes: 3 }))', () => {
+  it('reactElementToJSXString(<div aprop="1">content</div>, { maxInlineAttributesLineLength: 5 }))', () => {
     expect(
-      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3">content</div>, {maxInlineAttributes: 3})
-    ).toEqual(`<div aprop="1" bprop="2" cprop="3">
+      reactElementToJSXString(<div aprop="1">content</div>, {maxInlineAttributesLineLength: 5})
+    ).toEqual(`<div
+  aprop="1"
+>
   content
 </div>`);
   });
-  // eslint-disable-next-line max-len
-  it('reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4">content</div>, {maxInlineAttributes: 3}))', () => {
+  it('reactElementToJSXString(<div aprop="1" bprop="2">content</div>, { maxInlineAttributesLineLength: 10 }))', () => {
     expect(
-      reactElementToJSXString(<div aprop="1" bprop="2" cprop="3" dprop="4">content</div>, {maxInlineAttributes: 3})
+      reactElementToJSXString(<div aprop="1" bprop="2">content</div>, {maxInlineAttributesLineLength: 10})
     ).toEqual(`<div
   aprop="1"
   bprop="2"
-  cprop="3"
-  dprop="4"
 >
   content
 </div>`);

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ got \`${typeof Element}\``
 
     outMultilineAttr += `\n${spacer(lvl, tabStop)}`;
 
-    if (shouldRenderMultilineAttr(attributes, outInlineAttr, containsMultilineAttr, inline)) {
+    if (shouldRenderMultilineAttr(attributes, outInlineAttr, containsMultilineAttr, inline, lvl)) {
       out = outMultilineAttr;
     } else {
       out = outInlineAttr;
@@ -109,7 +109,7 @@ got \`${typeof Element}\``
       }
       out += `</${tagName}>`;
     } else {
-      if (!isInlineAttributeTooLong(attributes, outInlineAttr)) {
+      if (!isInlineAttributeTooLong(attributes, outInlineAttr, lvl)) {
         out += ' ';
       }
 
@@ -119,17 +119,17 @@ got \`${typeof Element}\``
     return out;
   }
 
-  function shouldRenderMultilineAttr(attributes, inlineAttributeString, containsMultilineAttr, inline) {
-    return (isInlineAttributeTooLong(attributes, inlineAttributeString) || containsMultilineAttr) && !inline;
+  function shouldRenderMultilineAttr(attributes, inlineAttributeString, containsMultilineAttr, inline, lvl) {
+    return (isInlineAttributeTooLong(attributes, inlineAttributeString, lvl) || containsMultilineAttr) && !inline;
   }
 
-  function isInlineAttributeTooLong(attributes, inlineAttributeString) {
+  function isInlineAttributeTooLong(attributes, inlineAttributeString, lvl) {
     if (typeof maxInlineAttributesLineLength === 'undefined') {
       // For backwards compatibility, if the new option is undefined, use previous logic to determine
       // whether or not to render multiline attributes based on the number of attributes
       return attributes.length > 1;
     } else {
-      return inlineAttributeString.length > maxInlineAttributesLineLength;
+      return spacer(lvl, tabStop).length + inlineAttributeString.length > maxInlineAttributesLineLength;
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ export default function reactElementToJSXString(
     showFunctions = false,
     tabStop = 2,
     useBooleanShorthandSyntax = true,
+    maxInlineAttributes = 1,
   } = {}
 ) {
   const getDisplayName = displayName || getDefaultDisplayName;
@@ -63,7 +64,7 @@ got \`${typeof Element}\``
         containsMultilineAttr = true;
       }
 
-      if ((attributes.length === 1 || inline) && !isMultilineAttr) {
+      if ((attributes.length <= maxInlineAttributes || inline) && !isMultilineAttr) {
         out += ' ';
       } else {
         out += `\n${spacer(lvl + 1, tabStop)}`;
@@ -76,7 +77,7 @@ got \`${typeof Element}\``
       }
     });
 
-    if ((attributes.length > 1 || containsMultilineAttr) && !inline) {
+    if ((attributes.length > maxInlineAttributes || containsMultilineAttr) && !inline) {
       out += `\n${spacer(lvl, tabStop)}`;
     }
 
@@ -103,7 +104,7 @@ got \`${typeof Element}\``
       }
       out += `</${tagName}>`;
     } else {
-      if (attributes.length <= 1) {
+      if (attributes.length <= maxInlineAttributes) {
         out += ' ';
       }
 


### PR DESCRIPTION
Would you be open to adding a `maxInlineAttributes` option (or something similarly named)?

I'm using your library to render demonstration documentation where I show a react component running on a page and the react component source on the same page. For some of my simpler components, I'd like to have all of their props render on the same line as the tag:
```jsx
<Header level={2} kind="heading1">
  Content
</Header>
```

See the tests I've added for more comprehensive examples of the behavior. All existing tests pass so this should not break any existing behavior.