### PR TITLE
Fix edge case when props contains double quote

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -57,6 +57,22 @@ describe('reactElementToJSXString(ReactElement)', () => {
     );
   });
 
+  it("reactElementToJSXString(React.createElement('div', {title: 'hello \"you\"'}))", () => {
+    expect(
+      reactElementToJSXString(
+        React.createElement('div', { title: 'hello "you"' })
+      )
+    ).toEqual('<div title="hello &quot;you&quot;" />');
+  });
+
+  it("reactElementToJSXString(React.createElement('div', {title: Symbol('hello \"you\"')})", () => {
+    expect(
+      reactElementToJSXString(
+        React.createElement('div', { title: Symbol('hello "you"') })
+      )
+    ).toEqual('<div title={Symbol(hello "you")} />');
+  });
+
   it('reactElementToJSXString(<div/>)', () => {
     expect(reactElementToJSXString(<div />)).toEqual('<div />');
   });

--- a/index-test.js
+++ b/index-test.js
@@ -65,6 +65,14 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual('<div title="hello &quot;you&quot;" />');
   });
 
+  it("reactElementToJSXString(React.createElement('div', {title: '<'hello' you & you>'}))", () => {
+    expect(
+      reactElementToJSXString(
+        React.createElement('div', { title: "<'hello' you & you>" })
+      )
+    ).toEqual('<div title="&lt;&#39;hello&#39; you &amp; you&gt;" />');
+  });
+
   it("reactElementToJSXString(React.createElement('div', {title: Symbol('hello \"you\"')})", () => {
     expect(
       reactElementToJSXString(

--- a/index.js
+++ b/index.js
@@ -202,7 +202,7 @@ got \`${typeof Element}\``
 
   function formatJSXAttribute(propValue, inline, lvl) {
     if (typeof propValue === 'string') {
-      return `"${propValue}"`;
+      return `"${propValue.replace(/"/g, '&quot;')}"`;
     }
 
     if (typeof propValue === 'symbol') {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import isPlainObject from 'is-plain-object';
 import stringify from 'stringify-object';
 import sortobject from 'sortobject';
 import traverse from 'traverse';
-import { fill } from 'lodash';
+import { fill, escape } from 'lodash';
 
 const defaultFunctionValue = fn => fn;
 
@@ -202,7 +202,7 @@ got \`${typeof Element}\``
 
   function formatJSXAttribute(propValue, inline, lvl) {
     if (typeof propValue === 'string') {
-      return `"${propValue.replace(/"/g, '&quot;')}"`;
+      return `"${escape(propValue)}"`;
     }
 
     if (typeof propValue === 'symbol') {


### PR DESCRIPTION
Looks like this case was not managed and that we encountered it 😉 