### PR TITLE
Remove props sort as it leads to isomorphism issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,9 +185,9 @@ got \`${typeof Element}\``
       );
     }
 
-    return formatted
-      .sort()
-      .map(propName => getJSXAttribute(propName, props[propName], inline, lvl));
+    return formatted.map(propName =>
+      getJSXAttribute(propName, props[propName], inline, lvl)
+    );
   }
 
   function getJSXAttribute(name, value, inline, lvl) {


### PR DESCRIPTION
I haven't fixed the tests yet as I want to discuss 1st about the
(probably good) reason of removing this props sort or make it an option
to toggle.

In our use case of this lib, this leads to invalid checksums for
universal/isomorphic rendering.