### PR TITLE
always filter out props that have a value of undefined

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -16,7 +16,12 @@ function NamedStatelessComponent(props) {
 
 class DefaultPropsComponent extends React.Component {}
 
-DefaultPropsComponent.defaultProps = { test: 'test', boolean: true };
+DefaultPropsComponent.defaultProps = {
+  test: 'test',
+  boolean: true,
+  number: 0,
+  undefinedProp: undefined,
+};
 
 class DisplayNamePrecedence extends React.Component {}
 
@@ -645,7 +650,9 @@ describe('reactElementToJSXString(ReactElement)', () => {
     expect(reactElementToJSXString(<DefaultPropsComponent />)).toEqual(
       `<DefaultPropsComponent
   boolean
+  number={0}
   test="test"
+  undefinedProp={undefined}
 />`
     );
   });

--- a/index.js
+++ b/index.js
@@ -181,7 +181,10 @@ got \`${typeof Element}\``
 
     if (!showDefaultProps) {
       formatted = formatted.filter(
-        key => (defaultProps[key] ? defaultProps[key] !== props[key] : true)
+        key =>
+          (typeof defaultProps[key] === 'undefined'
+            ? typeof props[key] !== 'undefined'
+            : defaultProps[key] !== props[key])
       );
     }
 


### PR DESCRIPTION
The logic for filtering out defaultProps wasn't taking into account falsey values that are actually defined as default props.