### PR TITLE
Add failing test on JSON escaping issue

### DIFF
--- a/index-test.js
+++ b/index-test.js
@@ -92,6 +92,26 @@ describe('reactElementToJSXString(ReactElement)', () => {
     );
   });
 
+  it("reactElementToJSXString(<div nested={{ hello: 'world', foo: 'esca'ped', bar: 42 }} root=\"root\"/>)", () => {
+    expect(
+      reactElementToJSXString(
+        <div
+          nested={{ hello: 'world', foo: 'esca\'"ped', bar: 42 }}
+          root="root"
+        />
+      )
+    ).toEqual(
+      `<div
+  nested={{
+    bar: 42,
+    foo: "esca'\\"ped",
+    hello: "world"
+  }}
+  root="root"
+/>`
+    );
+  });
+
   it("reactElementToJSXString(React.createElement('div', {title: Symbol('hello \"you\"')})", () => {
     expect(
       reactElementToJSXString(


### PR DESCRIPTION
This test is here to discuss about the change made by the commit https://github.com/algolia/react-element-to-jsx-string/commit/5c0ae3ef718259e23510106bc4d0093dd88085d5 to solve the issue #80 on string escaping. The proposed fix introduce a regression on a the JSON representation that is no more correctly escaped.

@vvo I would have your thought about this one, I will propose a PR to correctly fix both cases