### PR TITLE
Configure Renovate to rebase stale PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   },
   "license": "MIT",
   "repository": "algolia/react-element-to-jsx-string",
+  "renovate": {
+    "rebaseStalePrs": true
+  },
   "devDependencies": {
     "babel-cli": "6.24.1",
     "babel-eslint": "7.2.3",


### PR DESCRIPTION
This repository appears to have a setting that all PRs must be up-to-date with the base branch before merging. For example, #117:

![PR#117](https://www.evernote.com/l/AA92zSDhX2xPuLJNSknq0EimYUEZQEdcqPUB/image.png)

Therefore it is recommended to enable the setting `rebaseStalePrs` in Renovate so that it knows to keep branches up-to-date itself and save you the task of doing it. It means Renovate will rebase any of its PRs off master any time it runs and finds that the master branch has changed.