### PR TITLE
Allow react 16 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-test-renderer": "15.6.1"
   },
   "peerDependencies": {
-    "react": "^0.14.8 || ^15.0.1"
+    "react": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^16.0.0-beta || ^16.0.0-alpha"
   },
   "dependencies": {
     "collapse-white-space": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-test-renderer": "15.6.1"
   },
   "peerDependencies": {
-    "react": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^16.0.0-beta || ^16.0.0-alpha"
+    "react": "^0.14.8 || ^15.0.1 || ^16.0.0 || ^16.0.0-rc || ^16.0.0-beta || ^16.0.0-alpha"
   },
   "dependencies": {
     "collapse-white-space": "^1.0.3",


### PR DESCRIPTION
Ran tests with react 15 and react 16 and all passed.
This is necessary to use with react native >= 0.43 (latest is 0.47-rc).
@Spy-Seth @vvo 