### PR TITLE
[DO NOT MERGE] Detect stringified json children and escape them correctly

### DIFF
--- a/src/formatter/formatReactElementNode.spec.js
+++ b/src/formatter/formatReactElementNode.spec.js
@@ -94,4 +94,35 @@ describe('formatReactElementNode', () => {
       '<div a={<span b="42" />} />'
     );
   });
+
+  it('should format a react element with multiline children', () => {
+    const tree = {
+      type: 'ReactElement',
+      displayName: 'div',
+      defaultProps: {},
+      props: {},
+      childrens: [
+        {
+          type: 'string',
+          value: 'first line\nsecond line\nthird line',
+        },
+      ],
+    };
+
+    expect(formatReactElementNode(tree, false, 0, defaultOptions)).toEqual(
+      `<div>
+  first line
+  second line
+  third line
+</div>`
+    );
+
+    expect(formatReactElementNode(tree, false, 2, defaultOptions)).toEqual(
+      `<div>
+      first line
+      second line
+      third line
+    </div>`
+    );
+  });
 });

--- a/src/formatter/formatTreeNode.js
+++ b/src/formatter/formatTreeNode.js
@@ -13,8 +13,25 @@ export default (
   lvl: number,
   options: Options
 ): string => {
-  if (node.type === 'string' || node.type === 'number') {
-    return node.value ? escape(node.value.toString()) : '';
+  const { tabStop } = options;
+
+  if (node.type === 'number') {
+    return node.value.toString();
+  }
+
+  if (node.type === 'string') {
+    let str;
+    try {
+      if (inline) {
+        str = `{\`${JSON.stringify(JSON.parse(node.value))}\`}`;
+      } else {
+        str = `{\`${JSON.stringify(JSON.parse(node.value), null, tabStop)}\`}`;
+      }
+    } catch (error) {
+      str = node.value ? escape(node.value.toString()) : '';
+    }
+
+    return str;
   }
 
   if (node.type === 'ReactElement') {

--- a/src/formatter/formatTreeNode.spec.js
+++ b/src/formatter/formatTreeNode.spec.js
@@ -5,7 +5,26 @@ import formatTreeNode from './formatTreeNode';
 describe('formatTreeNode', () => {
   it('should escape JSX entity on string node', () => {
     expect(
-      formatTreeNode({ type: 'string', value: '{ foo: "bar" }' }, true, 0, {})
-    ).toBe('&lbrace; foo: "bar" &rbrace;');
+      formatTreeNode(
+        { type: 'string', value: 'Mister mustache :{' },
+        true,
+        0,
+        {}
+      )
+    ).toBe('Mister mustache :&lbrace;');
+  });
+
+  it('should detect JSON string and not escaping then', () => {
+    expect(
+      formatTreeNode({ type: 'string', value: '{ "foo": "bar" }' }, true, 0, {})
+    ).toBe('{`{"foo":"bar"}`}');
+
+    expect(
+      formatTreeNode({ type: 'string', value: '{ "foo": "bar" }' }, false, 0, {
+        tabStop: 2,
+      })
+    ).toBe(`{\`{
+  "foo": "bar"
+}\`}`);
   });
 });

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -347,6 +347,40 @@ describe('reactElementToJSXString(ReactElement)', () => {
     );
   });
 
+  it('reactElementToJSXString(<div>{`{"foo":"bar"}`}</div>)', () => {
+    expect(reactElementToJSXString(<script>{`{"foo":"bar"}`}</script>)).toEqual(
+      `<script>
+  {\`{
+    "foo": "bar"
+  }\`}
+</script>`
+    );
+  });
+
+  it('reactElementToJSXString(<div>{`foo\nbar`}</div>)', () => {
+    expect(reactElementToJSXString(<div>{`foo\nbar`}</div>)).toEqual(
+      `<div>
+  foo
+  bar
+</div>`
+    );
+
+    expect(
+      reactElementToJSXString(
+        <div>
+          <div>{`foo\nbar`}</div>
+        </div>
+      )
+    ).toEqual(
+      `<div>
+  <div>
+    foo
+    bar
+  </div>
+</div>`
+    );
+  });
+
   it('reactElementToJSXString(<div>Hello</div>, {tabStop: 4})', () => {
     expect(reactElementToJSXString(<div>Hello</div>, { tabStop: 4 })).toEqual(
       `<div>


### PR DESCRIPTION
Fix https://github.com/algolia/react-element-to-jsx-string/issues/128


The original aim of this PR was to manage JSON child. It also fix a bug with multi-line children string that were not correctly indented.