### PR TITLE
fix(formatting) Escape multi lines string nodes

### DIFF
--- a/src/formatter/formatReactElementNode.spec.js
+++ b/src/formatter/formatReactElementNode.spec.js
@@ -111,17 +111,17 @@ describe('formatReactElementNode', () => {
 
     expect(formatReactElementNode(tree, false, 0, defaultOptions)).toEqual(
       `<div>
-  first line
+  {\`first line
   second line
-  third line
+  third line\`}
 </div>`
     );
 
     expect(formatReactElementNode(tree, false, 2, defaultOptions)).toEqual(
       `<div>
-      first line
+      {\`first line
       second line
-      third line
+      third line\`}
     </div>`
     );
   });

--- a/src/formatter/formatTreeNode.js
+++ b/src/formatter/formatTreeNode.js
@@ -4,7 +4,7 @@ import formatReactElementNode from './formatReactElementNode';
 import type { Options } from './../options';
 import type { TreeNode } from './../tree';
 
-const jsxStopChars = ['<', '>', '{', '}'];
+const jsxStopChars = ['<', '>', '{', '}', '\n'];
 const shouldBeEscaped = (s: string) =>
   jsxStopChars.some(jsxStopChar => s.includes(jsxStopChar));
 

--- a/src/formatter/formatTreeNode.spec.js
+++ b/src/formatter/formatTreeNode.spec.js
@@ -49,8 +49,8 @@ describe('formatTreeNode', () => {
 
   it('should preserve the format of string', () => {
     expect(formatTreeNode({ type: 'string', value: 'foo\nbar' }, true, 0, {}))
-      .toBe(`foo
-bar`);
+      .toBe(`{\`foo
+bar\`}`);
 
     expect(
       formatTreeNode(

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -326,8 +326,8 @@ describe('reactElementToJSXString(ReactElement)', () => {
   it('reactElementToJSXString(<div>{`foo\nbar`}</div>)', () => {
     expect(reactElementToJSXString(<div>{`foo\nbar`}</div>)).toEqual(
       `<div>
-  foo
-  bar
+  {\`foo
+  bar\`}
 </div>`
     );
 
@@ -340,8 +340,8 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual(
       `<div>
   <div>
-    foo
-    bar
+    {\`foo
+    bar\`}
   </div>
 </div>`
     );


### PR DESCRIPTION
I consider that like a fix as for example we have the case of some markdown content string node:
if it's not protected then the carriage returns are lost at some point later when you render it.

We can also discuss that as a feature trough a toggled option.