### PR TITLE
Fix warning about access to PropTypes using React 15.5+ (fixes #213)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
 /* @flow */
 
-import * as React from 'react';
 import formatTree from './formatter/formatTree';
 import parseReactElement from './parser/parseReactElement';
+import type { Element as ReactElement } from 'react';
 import type { Options } from './options';
 
 const reactElementToJsxString = (
-  element: React.Element<any>,
+  element: ReactElement<any>,
   {
     filterProps = [],
     showDefaultProps = true,

--- a/src/parser/parseReactElement.js
+++ b/src/parser/parseReactElement.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import * as React from 'react';
+import React, { type Element as ReactElement } from 'react';
 import type { Options } from './../options';
 import {
   createStringTreeNode,
@@ -9,7 +9,7 @@ import {
 } from './../tree';
 import type { TreeNode } from './../tree';
 
-const getReactElementDisplayName = (element: React.Element<*>): string =>
+const getReactElementDisplayName = (element: ReactElement<*>): string =>
   element.type.displayName ||
   element.type.name || // function name
   (typeof element.type === 'function' // function without a name, you should provide one
@@ -35,7 +35,7 @@ const filterProps = (originalProps: {}, cb: (any, string) => boolean) => {
 };
 
 const parseReactElement = (
-  element: React.Element<*> | string | number,
+  element: ReactElement<*> | string | number,
   options: Options
 ): TreeNode => {
   const { displayName: displayNameFn = getReactElementDisplayName } = options;


### PR DESCRIPTION
Explicit import of React's types to avoid star import that leads to warning about access to PropTypes.