### PR TITLE
chore(deps): Remove `collapse-white-space` from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react": "^0.14.8 || ^15.0.1 || ^16.0.0"
   },
   "dependencies": {
-    "collapse-white-space": "1.0.3",
     "is-plain-object": "2.0.4",
     "sortobject": "1.1.1",
     "stringify-object": "3.2.1"

--- a/src/formatter/formatComplexDataStructure.js
+++ b/src/formatter/formatComplexDataStructure.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-import collapse from 'collapse-white-space';
 import { isValidElement } from 'react';
 import stringify from 'stringify-object';
 import sortobject from 'sortobject';
@@ -41,7 +40,8 @@ export default (
   });
 
   if (inline) {
-    return collapse(stringifiedValue)
+    return stringifiedValue
+      .replace(/\s+/g, ' ')
       .replace(/{ /g, '{')
       .replace(/ }/g, '}')
       .replace(/\[ /g, '[')

--- a/yarn.lock
+++ b/yarn.lock
@@ -1337,7 +1337,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-collapse-white-space@1.0.3, collapse-white-space@^1.0.0:
+collapse-white-space@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.3.tgz#4b906f670e5a963a87b76b0e1689643341b6023c"
 


### PR DESCRIPTION
Remove `collapse-white-space` from deps since module is just a single simple regexp:
https://github.com/wooorm/collapse-white-space/blob/master/index.js#L7