### PR TITLE
fix(formatting): Date/RegExp values output by formatComplexDataStructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "dependencies": {
     "collapse-white-space": "1.0.3",
     "is-plain-object": "2.0.4",
-    "sortobject": "1.1.1",
     "stringify-object": "3.2.1"
   }
 }

--- a/src/formatter/formatComplexDataStructure.js
+++ b/src/formatter/formatComplexDataStructure.js
@@ -3,7 +3,7 @@
 import collapse from 'collapse-white-space';
 import { isValidElement } from 'react';
 import stringify from 'stringify-object';
-import sortobject from 'sortobject';
+import sortObject from './sortObject';
 import parseReactElement from './../parser/parseReactElement';
 import formatTreeNode from './formatTreeNode';
 import spacer from './spacer';
@@ -17,7 +17,7 @@ export default (
   lvl: number,
   options: Options
 ): string => {
-  const normalizedValue = sortobject(value);
+  const normalizedValue = sortObject(value);
 
   const stringifiedValue = stringify(normalizedValue, {
     transform: (currentObj, prop, originalResult) => {

--- a/src/formatter/formatComplexDataStructure.spec.js
+++ b/src/formatter/formatComplexDataStructure.spec.js
@@ -86,4 +86,20 @@ describe('formatComplexDataStructure', () => {
   it('should format an empty array', () => {
     expect(formatComplexDataStructure([], false, 0, options)).toEqual('[]');
   });
+
+  it('should format an object that contains a date', () => {
+    const fixture = { a: new Date('2017-11-13T00:00:00.000Z') };
+
+    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
+      `{a: new Date('2017-11-13T00:00:00.000Z')}`
+    );
+  });
+
+  it('should format an object that contains a regexp', () => {
+    const fixture = { a: /test/g };
+
+    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
+      `{a: /test/g}`
+    );
+  });
 });

--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -1,0 +1,27 @@
+/* @flow */
+
+export default function sortObject(value: any): any {
+  // return non-object value as is
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  // return date and regexp values as is
+  if (value instanceof Date || value instanceof RegExp) {
+    return value;
+  }
+
+  // make a copy of array with each item passed through sortObject()
+  if (Array.isArray(value)) {
+    return value.map(sortObject);
+  }
+
+  // make a copy of object with key sorted
+  return Object.keys(value)
+    .sort()
+    .reduce((result, key) => {
+      // eslint-disable-next-line no-param-reassign
+      result[key] = sortObject(value[key]);
+      return result;
+    }, {});
+}

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import sortObject from './sortObject';
+
+describe('sortObject', () => {
+  it('should sort keys in objects', () => {
+    const fixture = {
+      c: 2,
+      b: { x: 1, c: 'ccc' },
+      a: [{ foo: 1, bar: 2 }],
+    };
+
+    expect(JSON.stringify(sortObject(fixture))).toEqual(
+      JSON.stringify({
+        a: [{ bar: 2, foo: 1 }],
+        b: { c: 'ccc', x: 1 },
+        c: 2,
+      })
+    );
+  });
+
+  it('should process an array', () => {
+    const fixture = [{ foo: 1, bar: 2 }, null, { b: 1, c: 2, a: 3 }];
+
+    expect(JSON.stringify(sortObject(fixture))).toEqual(
+      JSON.stringify([{ bar: 2, foo: 1 }, null, { a: 3, b: 1, c: 2 }])
+    );
+  });
+
+  it('should not break special values', () => {
+    const date = new Date();
+    const regexp = /test/g;
+    const fixture = {
+      a: [date, regexp],
+      b: regexp,
+      c: date,
+    };
+
+    expect(sortObject(fixture)).toEqual({
+      a: [date, regexp],
+      b: regexp,
+      c: date,
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1795,10 +1795,6 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-editions@^1.1.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.3.tgz#0907101bdda20fac3cbe334c27cbd0688dc99a5b"
-
 elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
@@ -4697,12 +4693,6 @@ sntp@2.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
   dependencies:
     hoek "4.x.x"
-
-sortobject@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/sortobject/-/sortobject-1.1.1.tgz#4f695d4d44ed0a4c06482c34c2582a2dcdc2ab34"
-  dependencies:
-    editions "^1.1.1"
 
 source-map-support@^0.4.15:
   version "0.4.18"


### PR DESCRIPTION
`sortobject` breaks output of Date and RegExp values, since makes an object copy of those values instead returning as is. Therefore, `formatComplexDataStructure` for following object

```js
{
    date: new Date('2017-11-13T00:00:00.000Z'),
    regexp: /test/g
}
```

outputs

```js
{
    date: {},
    regexp: {}
}
```

We can fix `sortobject` by sending a PR. But its [implementation is too verbose](https://github.com/bevry/sortobject/blob/master/source/index.js) for such simple task. So I decided to add an own implementation of `sortObject` instead of patching `sortobject`. This also helps keep things simpler and allows adjust behaviour if needed.