### PR TITLE
qa(test): test the library agains more react and node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,26 @@
+dist: trusty
+sudo: false
+
 language: node_js
-node_js: stable
-branches:
-  only:
-    - master
-    - /^greenkeeper\/.*$/
+
+node_js: node # lastest
+
 cache: yarn
 
-# Since the upgrade to Ubuntu Precise, yarn is not available to run scripts: `yarn run foo`
-# So let's install it manually
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  # Install the latest yarn version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s
   - export PATH="$HOME/.yarn/bin:$PATH"
+  - yarn --version
+
+install:
+  - yarn install
+
+script:
+  - yarn run test
+  - yarn run lint
+  - yarn run flow
+  - yarn run smoke 15.6.2
+  - yarn run smoke 16.1.0
+  - yarn run smoke default
+  - yarn run smoke next

--- a/package.json
+++ b/package.json
@@ -12,12 +12,16 @@
     "prepublish": "npm run build",
     "prebuild": "mkdir -p dist && rm -rf ./dist/*",
     "prettier:fix": "prettier --write \"**/*.{js,json}\"",
-    "test": "jest && npm run lint && npm run flow",
+    "test": "jest",
     "test:watch": "jest --watch",
-    "release": "./release.sh"
+    "release": "./release.sh",
+    "smoke": "node tests/smoke/run"
   },
   "lint-staged": {
-    "*.js": ["prettier --write \"**/*.{js,json}\"", "git add"]
+    "*.js": [
+      "prettier --write \"**/*.{js,json}\"",
+      "git add"
+    ]
   },
   "author": {
     "name": "Algolia, Inc.",
@@ -67,7 +71,6 @@
     "mversion": "1.10.1",
     "prettier": "1.8.2",
     "react": "16.2.0",
-    "react-dom": "16.2.0",
     "react-test-renderer": "16.2.0"
   },
   "peerDependencies": {

--- a/tests/smoke/.gitignore
+++ b/tests/smoke/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package.json
+yarn.lock

--- a/tests/smoke/prepare.js
+++ b/tests/smoke/prepare.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+const execSync = require('child_process').execSync;
+
+const requestedReactVersion = process.argv[2];
+if (!requestedReactVersion) {
+  throw new Error("React version is missing: '$ ./prepare 16.0.0'");
+}
+
+const nodeModulesPath = path.join(__dirname, 'node_modules');
+const packageJsonPath = path.join(__dirname, 'package.json');
+
+const deleteExistingDependencies = () => () => {
+  if (fs.existsSync(nodeModulesPath)) {
+    execSync(`rm -r "${nodeModulesPath}"`, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+  }
+
+  if (fs.existsSync(packageJsonPath)) {
+    execSync(`rm "${packageJsonPath}"`, {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+  }
+};
+
+const preparePackageJson = reactVersion => () => {
+  if (reactVersion === 'default') {
+    return;
+  }
+
+  const packageJson = {
+    name: 'smoke',
+    version: '0.0.1',
+    main: 'index.js',
+    license: 'MIT',
+    private: true,
+    dependencies: {
+      react: reactVersion,
+    },
+  };
+
+  fs.writeFileSync(
+    path.join(__dirname, 'package.json'),
+    JSON.stringify(packageJson, null, 2)
+  );
+};
+
+const installDependencies = () => () =>
+  new Promise(() => {
+    if (!fs.existsSync(packageJsonPath)) {
+      return;
+    }
+
+    execSync('yarn install --no-lockfile', {
+      cwd: __dirname,
+      stdio: 'inherit',
+    });
+  });
+
+Promise.resolve()
+  .then(() =>
+    console.log(`Requested "react" version: "${requestedReactVersion}"`)
+  )
+  .then(deleteExistingDependencies())
+  .then(preparePackageJson(requestedReactVersion))
+  .then(installDependencies())
+  .catch(err => console.error(err));

--- a/tests/smoke/run.js
+++ b/tests/smoke/run.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const execFileSync = require('child_process').execFileSync;
+const path = require('path');
+
+execFileSync(path.join(__dirname, 'prepare.js'), [process.argv[2]], {
+  cwd: __dirname,
+  stdio: 'inherit',
+});
+
+execFileSync(path.join(__dirname, 'smoke.js'), {
+  cwd: __dirname,
+  stdio: 'inherit',
+});

--- a/tests/smoke/smoke.js
+++ b/tests/smoke/smoke.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+
+const expect = require('expect');
+const React = require('react');
+const reactElementToJsxString = require('./../../dist/').default;
+
+console.log(`Tested "react" version: "${React.version}"`);
+
+const tree = React.createElement(
+  'div',
+  { foo: 51 },
+  React.createElement('h1', {}, 'Hello world')
+);
+
+expect(reactElementToJsxString(tree)).toEqual(
+  `<div foo={51}>
+  <h1>
+    Hello world
+  </h1>
+</div>`
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4378,15 +4378,6 @@ rc@^1.0.1, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@16.2.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.2.0.tgz#69003178601c0ca19b709b33a83369fe6124c044"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-test-renderer@16.2.0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"


### PR DESCRIPTION
Do not be scare by the number of line of code, it's mostly some `yarn.lock` file

This PR introduce a new tests suite called `smoke`. It tests that the library seems to works with multiple version React (v0.14, v15 and v16): it only validate some basic usage.

It also rework the `travis.yml` file to test our code with multiple node versions (the last v7, the last LTS/v8, and the last v9)