### PR TITLE
fix(browser): Add IE 11 support

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,9 @@ export default {
   plugins: [
     babel({
       babelrc: false,
-      exclude: 'node_modules/**', // only transpile our source code
+      // Don't transpile `node_modules` except for `stringify-object`. This enables IE 11 support
+      // and minification in older versions of Uglify.
+      exclude: 'node_modules/!(stringify-object)/**',
       presets: [
         [
           'es2015',


### PR DESCRIPTION
This adds IE 11 support as well as support for older versions of Uglify.

It does so by transpiling `stringify-object` with babel.

Closes #211, #285