### PR TITLE
formatReactElementNode: convert displayName to String

### DIFF
--- a/src/formatter/formatReactElementNode.js
+++ b/src/formatter/formatReactElementNode.js
@@ -119,7 +119,7 @@ export default (
     tabStop,
   } = options;
 
-  let out = `<${displayName}`;
+  let out = `<${String(displayName)}`;
 
   let outInlineAttr = out;
   let outMultilineAttr = out;
@@ -203,7 +203,7 @@ export default (
       out += '\n';
       out += spacer(newLvl - 1, tabStop);
     }
-    out += `</${displayName}>`;
+    out += `</${String(displayName)}>`;
   } else {
     if (
       !isInlineAttributeTooLong(


### PR DESCRIPTION
If the `displayName` for a component turns out to be a `symbol` for some reason, ECMAScript will fail early when trying to implicitly convert it to a string. This explicitly converts to a string so that at least execution isn't halted.