### PR TITLE
Handle multiple words before trailing space, and after leading space

### DIFF
--- a/src/formatter/formatTreeNode.js
+++ b/src/formatter/formatTreeNode.js
@@ -20,11 +20,11 @@ const escape = (s: string) => {
 const preserveTrailingSpace = (s: string) => {
   let result = s;
   if (result.endsWith(' ')) {
-    result = result.replace(/^(\S*)(\s*)$/, "$1{'$2'}");
+    result = result.replace(/^(.*?)(\s+)$/, "$1{'$2'}");
   }
 
   if (result.startsWith(' ')) {
-    result = result.replace(/^(\s*)(\S*)$/, "{'$1'}$2");
+    result = result.replace(/^(\s+)(.*)$/, "{'$1'}$2");
   }
 
   return result;

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -559,19 +559,19 @@ describe('reactElementToJSXString(ReactElement)', () => {
     );
   });
 
-  it('reactElementToJSXString(<div>\nfoo <span>bar</span> baz\n</div>)', () => {
+  it('reactElementToJSXString(<div>\nfoo bar <span> baz </span> qux quux\n</div>)', () => {
     expect(
       reactElementToJSXString(
         <div>
-          foo <span>bar</span> baz
+          foo bar <span> baz </span> qux quux
         </div>
       )
     ).toEqual(`<div>
-  foo{' '}
+  foo bar{' '}
   <span>
-    bar
+    {' '}baz{' '}
   </span>
-  {' '}baz
+  {' '}qux quux
 </div>`);
   });
 


### PR DESCRIPTION
`/^(\S*)(\s*)$/` will not match if there are multiple words before the trailing space due to it trying to match non-space characters before the trailing space.

Without the fix, the following test will fail

![image](https://user-images.githubusercontent.com/269/86042647-51977900-b9fc-11ea-97b9-23b9b4c5a9dd.png)
