### PR TITLE
Explicitly convert displayName to string 

### DIFF
--- a/src/formatter/formatReactElementNode.js
+++ b/src/formatter/formatReactElementNode.js
@@ -203,7 +203,7 @@ export default (
       out += '\n';
       out += spacer(newLvl - 1, tabStop);
     }
-    out += `</${displayName}>`;
+    out += `</${displayName.toString()}>`;
   } else {
     if (
       !isInlineAttributeTooLong(


### PR DESCRIPTION
A React Elements displayName is not necessarily a string, and Symbols are not automatically converted to strings.

A case where the displayName is a symbol is for example the `React.Profiler` element.

For reference symbols will throw error: 
https://stackoverflow.com/questions/44425974/why-symbols-not-convert-string-implicitly
Same seems to happen for String.concat.

This would just be a simple fail safe change for the case where an elements displayName is a symbol.