### PR TITLE
fix: handle invalid Date objects (#605)

### DIFF
--- a/src/formatter/formatPropValue.js
+++ b/src/formatter/formatPropValue.js
@@ -54,6 +54,9 @@ const formatPropValue = (
   }
 
   if (propValue instanceof Date) {
+    if (isNaN(propValue.valueOf())) {
+      return `{new Date(NaN)}`;
+    }
     return `{new Date("${propValue.toISOString()}")}`;
   }
 

--- a/src/formatter/formatPropValue.spec.js
+++ b/src/formatter/formatPropValue.spec.js
@@ -93,6 +93,12 @@ describe('formatPropValue', () => {
     ).toBe('{new Date("2017-01-01T11:00:00.000Z")}');
   });
 
+  it('should format an invalid date prop value', () => {
+    expect(formatPropValue(new Date(NaN), false, 0, {})).toBe(
+      '{new Date(NaN)}'
+    );
+  });
+
   it('should format an object prop value', () => {
     expect(formatPropValue({ foo: 42 }, false, 0, {})).toBe(
       '{*Mocked formatComplexDataStructure result*}'


### PR DESCRIPTION
calling toISOString() on an invalid Date object will throw a Range Error