### PR TITLE
feature(formatting) print function children

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,18 +84,24 @@ console.log(reactElementToJSXString(<div a="1" b="2">Hello, world!</div>));
 
   If false, default props are omitted unless they differ from from the default value.
 
-**options.showFunctions: boolean, default false**
+**options.showFunctions: boolean | (fn: Function, prop: string) => boolean, default false**
 
   If true, functions bodies are shown.
 
   If false, functions bodies are replaced with `function noRefCheck() {}`.
 
-**options.functionValue: function, default `(fn) => fn`**
+  If a function is passed, it will be called for each function prop with its value and key, and will not print bodies of functions that return false.
+
+**options.functionValue: (fn: Function, prop: string) => Function | string, default undefined**
 
   Allows you to override the default formatting of function values.
 
   `functionValue` receives the original function reference as input
-  and should send any value as output.
+  and should return a new function or formatted string.
+
+  Pre-defined inline and multi-line formatters are exported as `inlineFunction` and `preserveFunctionLineBreak` respectively.
+
+  The default formatting depends on context: multi-line for function children and inline for props.
 
 **options.tabStop: number, default 2**
 

--- a/src/formatter/formatComplexDataStructure.js
+++ b/src/formatter/formatComplexDataStructure.js
@@ -11,6 +11,7 @@ import type { Options } from './../options';
 
 export default (
   value: Object | Array<any>,
+  name: string,
   inline: boolean,
   lvl: number,
   options: Options
@@ -31,7 +32,7 @@ export default (
       }
 
       if (typeof currentValue === 'function') {
-        return formatFunction(currentValue, true, lvl, options);
+        return formatFunction(currentValue, name, true, lvl, options);
       }
 
       return originalResult;

--- a/src/formatter/formatComplexDataStructure.js
+++ b/src/formatter/formatComplexDataStructure.js
@@ -31,7 +31,7 @@ export default (
       }
 
       if (typeof currentValue === 'function') {
-        return formatFunction(currentValue, options);
+        return formatFunction(currentValue, true, lvl, options);
       }
 
       return originalResult;

--- a/src/formatter/formatComplexDataStructure.spec.js
+++ b/src/formatter/formatComplexDataStructure.spec.js
@@ -15,7 +15,9 @@ describe('formatComplexDataStructure', () => {
   it('should format an object', () => {
     const fixture = { a: 1, b: { c: 'ccc' } };
 
-    expect(formatComplexDataStructure(fixture, false, 0, options)).toEqual(
+    expect(
+      formatComplexDataStructure(fixture, 'foo', false, 0, options)
+    ).toEqual(
       `{
     a: 1,
     b: {
@@ -28,19 +30,23 @@ describe('formatComplexDataStructure', () => {
   it('should format inline an object', () => {
     const fixture = { a: 1, b: { c: 'ccc' } };
 
-    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
-      "{a: 1, b: {c: 'ccc'}}"
-    );
+    expect(
+      formatComplexDataStructure(fixture, 'foo', true, 0, options)
+    ).toEqual("{a: 1, b: {c: 'ccc'}}");
   });
 
   it('should format an empty object', () => {
-    expect(formatComplexDataStructure({}, false, 0, options)).toEqual('{}');
+    expect(formatComplexDataStructure({}, 'foo', false, 0, options)).toEqual(
+      '{}'
+    );
   });
 
   it('should order the object keys', () => {
     const fixture = { b: { d: 'ddd', c: 'ccc' }, a: 1 };
 
-    expect(formatComplexDataStructure(fixture, false, 0, options)).toEqual(
+    expect(
+      formatComplexDataStructure(fixture, 'foo', false, 0, options)
+    ).toEqual(
       `{
     a: 1,
     b: {
@@ -54,7 +60,9 @@ describe('formatComplexDataStructure', () => {
   it('should format an array', () => {
     const fixture = [1, '2', true, false, null];
 
-    expect(formatComplexDataStructure(fixture, false, 0, options)).toEqual(
+    expect(
+      formatComplexDataStructure(fixture, 'foo', false, 0, options)
+    ).toEqual(
       `[
     1,
     '2',
@@ -68,15 +76,17 @@ describe('formatComplexDataStructure', () => {
   it('should format inline an array ', () => {
     const fixture = [1, '2', true, false, null];
 
-    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
-      "[1, '2', true, false, null]"
-    );
+    expect(
+      formatComplexDataStructure(fixture, 'foo', true, 0, options)
+    ).toEqual("[1, '2', true, false, null]");
   });
 
   it('should format an object that contains a react element', () => {
     const fixture = { a: createFakeReactElement('BarBar') };
 
-    expect(formatComplexDataStructure(fixture, false, 0, options)).toEqual(
+    expect(
+      formatComplexDataStructure(fixture, 'foo', false, 0, options)
+    ).toEqual(
       `{
     a: <BarBar />
   }`
@@ -84,23 +94,25 @@ describe('formatComplexDataStructure', () => {
   });
 
   it('should format an empty array', () => {
-    expect(formatComplexDataStructure([], false, 0, options)).toEqual('[]');
+    expect(formatComplexDataStructure([], 'foo', false, 0, options)).toEqual(
+      '[]'
+    );
   });
 
   it('should format an object that contains a date', () => {
     const fixture = { a: new Date('2017-11-13T00:00:00.000Z') };
 
-    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
-      `{a: new Date('2017-11-13T00:00:00.000Z')}`
-    );
+    expect(
+      formatComplexDataStructure(fixture, 'foo', true, 0, options)
+    ).toEqual(`{a: new Date('2017-11-13T00:00:00.000Z')}`);
   });
 
   it('should format an object that contains a regexp', () => {
     const fixture = { a: /test/g };
 
-    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
-      `{a: /test/g}`
-    );
+    expect(
+      formatComplexDataStructure(fixture, 'foo', true, 0, options)
+    ).toEqual(`{a: /test/g}`);
   });
 
   it('should replace a function with noRefCheck', () => {
@@ -110,9 +122,9 @@ describe('formatComplexDataStructure', () => {
       },
     };
 
-    expect(formatComplexDataStructure(fixture, true, 0, options)).toEqual(
-      '{a: function noRefCheck() {}}'
-    );
+    expect(
+      formatComplexDataStructure(fixture, 'foo', true, 0, options)
+    ).toEqual('{a: function noRefCheck() {}}');
   });
 
   it('should format a function', () => {
@@ -123,7 +135,7 @@ describe('formatComplexDataStructure', () => {
     };
 
     expect(
-      formatComplexDataStructure(fixture, true, 0, {
+      formatComplexDataStructure(fixture, 'foo', true, 0, {
         ...options,
         showFunctions: true,
       })
@@ -138,7 +150,7 @@ describe('formatComplexDataStructure', () => {
     };
 
     expect(
-      formatComplexDataStructure(fixture, true, 0, {
+      formatComplexDataStructure(fixture, 'foo', true, 0, {
         ...options,
         functionValue: () => '<Test />',
       })

--- a/src/formatter/formatFunction.js
+++ b/src/formatter/formatFunction.js
@@ -14,6 +14,7 @@ export const preserveFunctionLineBreak = (fn: any): string => fn.toString();
 
 export default (
   fn: Function,
+  prop: string,
   inline: boolean,
   lvl: number,
   options: Options
@@ -21,9 +22,14 @@ export default (
   const { functionValue, showFunctions } = options;
   const functionFn =
     functionValue || (inline ? inlineFunction : preserveFunctionLineBreak);
-  const shouldShowFunction = showFunctions || functionValue;
+  const shouldShowFunction = Boolean(
+    functionValue ||
+      (typeof showFunctions === 'function'
+        ? showFunctions(fn, prop)
+        : showFunctions)
+  );
 
-  return String(functionFn(shouldShowFunction ? fn : noRefCheck))
+  return String(functionFn(shouldShowFunction ? fn : noRefCheck, prop))
     .split('\n')
     .map(ln => spacer(lvl, options.tabStop) + ln)
     .join('\n')

--- a/src/formatter/formatFunction.js
+++ b/src/formatter/formatFunction.js
@@ -1,4 +1,5 @@
 import type { Options } from './../options';
+import spacer from './spacer';
 
 function noRefCheck() {}
 
@@ -11,13 +12,20 @@ export const inlineFunction = (fn: any): string =>
 
 export const preserveFunctionLineBreak = (fn: any): string => fn.toString();
 
-const defaultFunctionValue = inlineFunction;
+export default (
+  fn: Function,
+  inline: boolean,
+  lvl: number,
+  options: Options
+): string => {
+  const { functionValue, showFunctions } = options;
+  const functionFn =
+    functionValue || (inline ? inlineFunction : preserveFunctionLineBreak);
+  const shouldShowFunction = showFunctions || functionValue;
 
-export default (fn: Function, options: Options): string => {
-  const { functionValue = defaultFunctionValue, showFunctions } = options;
-  if (!showFunctions && functionValue === defaultFunctionValue) {
-    return functionValue(noRefCheck);
-  }
-
-  return functionValue(fn);
+  return String(functionFn(shouldShowFunction ? fn : noRefCheck))
+    .split('\n')
+    .map(ln => spacer(lvl, options.tabStop) + ln)
+    .join('\n')
+    .trim();
 };

--- a/src/formatter/formatFunction.spec.js
+++ b/src/formatter/formatFunction.spec.js
@@ -12,36 +12,38 @@ function hello() {
 
 describe('formatFunction', () => {
   it('should replace a function with noRefCheck without showFunctions option', () => {
-    expect(formatFunction(hello, {})).toEqual('function noRefCheck() {}');
+    expect(formatFunction(hello, true, 0, {})).toEqual(
+      'function noRefCheck() {}'
+    );
   });
 
   it('should replace a function with noRefCheck if showFunctions is false', () => {
-    expect(formatFunction(hello, { showFunctions: false })).toEqual(
+    expect(formatFunction(hello, true, 0, { showFunctions: false })).toEqual(
       'function noRefCheck() {}'
     );
   });
 
   it('should format a function if showFunctions is true', () => {
-    expect(formatFunction(hello, { showFunctions: true })).toEqual(
+    expect(formatFunction(hello, true, 0, { showFunctions: true })).toEqual(
       'function hello() {return 1;}'
     );
   });
 
   it('should format a function without name if showFunctions is true', () => {
-    expect(formatFunction(() => 1, { showFunctions: true })).toEqual(
+    expect(formatFunction(() => 1, true, 0, { showFunctions: true })).toEqual(
       'function () {return 1;}'
     );
   });
 
   it('should use the functionValue option', () => {
-    expect(formatFunction(hello, { functionValue: () => '<Test />' })).toEqual(
-      '<Test />'
-    );
+    expect(
+      formatFunction(hello, true, 0, { functionValue: () => '<Test />' })
+    ).toEqual('<Test />');
   });
 
   it('should use the functionValue option even if showFunctions is true', () => {
     expect(
-      formatFunction(hello, {
+      formatFunction(hello, true, 0, {
         showFunctions: true,
         functionValue: () => '<Test />',
       })
@@ -50,10 +52,22 @@ describe('formatFunction', () => {
 
   it('should use the functionValue option even if showFunctions is false', () => {
     expect(
-      formatFunction(hello, {
+      formatFunction(hello, true, 0, {
         showFunctions: false,
         functionValue: () => '<Test />',
       })
     ).toEqual('<Test />');
+  });
+
+  it('should format multi-line function', () => {
+    expect(
+      formatFunction(hello, false, 0, { showFunctions: true, tabStop: 2 })
+    ).toEqual('function hello() {\n  return 1;\n}');
+  });
+
+  it('should format multi-line function with indentation', () => {
+    expect(
+      formatFunction(hello, false, 1, { showFunctions: true, tabStop: 2 })
+    ).toEqual('function hello() {\n    return 1;\n  }');
   });
 });

--- a/src/formatter/formatFunction.spec.js
+++ b/src/formatter/formatFunction.spec.js
@@ -12,38 +12,40 @@ function hello() {
 
 describe('formatFunction', () => {
   it('should replace a function with noRefCheck without showFunctions option', () => {
-    expect(formatFunction(hello, true, 0, {})).toEqual(
+    expect(formatFunction(hello, 'prop', true, 0, {})).toEqual(
       'function noRefCheck() {}'
     );
   });
 
   it('should replace a function with noRefCheck if showFunctions is false', () => {
-    expect(formatFunction(hello, true, 0, { showFunctions: false })).toEqual(
-      'function noRefCheck() {}'
-    );
+    expect(
+      formatFunction(hello, 'prop', true, 0, { showFunctions: false })
+    ).toEqual('function noRefCheck() {}');
   });
 
   it('should format a function if showFunctions is true', () => {
-    expect(formatFunction(hello, true, 0, { showFunctions: true })).toEqual(
-      'function hello() {return 1;}'
-    );
+    expect(
+      formatFunction(hello, 'prop', true, 0, { showFunctions: true })
+    ).toEqual('function hello() {return 1;}');
   });
 
   it('should format a function without name if showFunctions is true', () => {
-    expect(formatFunction(() => 1, true, 0, { showFunctions: true })).toEqual(
-      'function () {return 1;}'
-    );
+    expect(
+      formatFunction(() => 1, 'prop', true, 0, { showFunctions: true })
+    ).toEqual('function () {return 1;}');
   });
 
   it('should use the functionValue option', () => {
     expect(
-      formatFunction(hello, true, 0, { functionValue: () => '<Test />' })
+      formatFunction(hello, 'prop', true, 0, {
+        functionValue: () => '<Test />',
+      })
     ).toEqual('<Test />');
   });
 
   it('should use the functionValue option even if showFunctions is true', () => {
     expect(
-      formatFunction(hello, true, 0, {
+      formatFunction(hello, 'prop', true, 0, {
         showFunctions: true,
         functionValue: () => '<Test />',
       })
@@ -52,7 +54,7 @@ describe('formatFunction', () => {
 
   it('should use the functionValue option even if showFunctions is false', () => {
     expect(
-      formatFunction(hello, true, 0, {
+      formatFunction(hello, 'prop', true, 0, {
         showFunctions: false,
         functionValue: () => '<Test />',
       })
@@ -61,13 +63,19 @@ describe('formatFunction', () => {
 
   it('should format multi-line function', () => {
     expect(
-      formatFunction(hello, false, 0, { showFunctions: true, tabStop: 2 })
+      formatFunction(hello, 'prop', false, 0, {
+        showFunctions: true,
+        tabStop: 2,
+      })
     ).toEqual('function hello() {\n  return 1;\n}');
   });
 
   it('should format multi-line function with indentation', () => {
     expect(
-      formatFunction(hello, false, 1, { showFunctions: true, tabStop: 2 })
+      formatFunction(hello, 'prop', false, 1, {
+        showFunctions: true,
+        tabStop: 2,
+      })
     ).toEqual('function hello() {\n    return 1;\n  }');
   });
 });

--- a/src/formatter/formatProp.js
+++ b/src/formatter/formatProp.js
@@ -28,7 +28,13 @@ export default (
 
   const { useBooleanShorthandSyntax, tabStop } = options;
 
-  const formattedPropValue = formatPropValue(usedValue, inline, lvl, options);
+  const formattedPropValue = formatPropValue(
+    usedValue,
+    name,
+    inline,
+    lvl,
+    options
+  );
 
   let attributeFormattedInline = ' ';
   let attributeFormattedMultiline = `\n${spacer(lvl + 1, tabStop)}`;

--- a/src/formatter/formatProp.spec.js
+++ b/src/formatter/formatProp.spec.js
@@ -30,6 +30,7 @@ describe('formatProp', () => {
 
     expect(formatPropValue).toHaveBeenCalledWith(
       'bar',
+      'foo',
       true,
       0,
       defaultOptions
@@ -50,6 +51,7 @@ describe('formatProp', () => {
 
     expect(formatPropValue).toHaveBeenCalledWith(
       'baz',
+      'foo',
       true,
       0,
       defaultOptions
@@ -70,6 +72,7 @@ describe('formatProp', () => {
 
     expect(formatPropValue).toHaveBeenCalledWith(
       'bar',
+      'foo',
       true,
       0,
       defaultOptions
@@ -93,7 +96,7 @@ describe('formatProp', () => {
       isMultilineAttribute: false,
     });
 
-    expect(formatPropValue).toHaveBeenCalledWith(true, true, 0, options);
+    expect(formatPropValue).toHaveBeenCalledWith(true, 'foo', true, 0, options);
   });
 
   it('should ignore a falsy boolean prop (with short syntax)', () => {
@@ -112,7 +115,13 @@ describe('formatProp', () => {
       isMultilineAttribute: false,
     });
 
-    expect(formatPropValue).toHaveBeenCalledWith(false, true, 0, options);
+    expect(formatPropValue).toHaveBeenCalledWith(
+      false,
+      'foo',
+      true,
+      0,
+      options
+    );
   });
 
   it('should format a truthy boolean prop (with explicit syntax)', () => {
@@ -132,7 +141,7 @@ describe('formatProp', () => {
       isMultilineAttribute: false,
     });
 
-    expect(formatPropValue).toHaveBeenCalledWith(true, true, 0, options);
+    expect(formatPropValue).toHaveBeenCalledWith(true, 'foo', true, 0, options);
   });
 
   it('should format a falsy boolean prop (with explicit syntax)', () => {
@@ -152,7 +161,13 @@ describe('formatProp', () => {
       isMultilineAttribute: false,
     });
 
-    expect(formatPropValue).toHaveBeenCalledWith(false, true, 0, options);
+    expect(formatPropValue).toHaveBeenCalledWith(
+      false,
+      'foo',
+      true,
+      0,
+      options
+    );
   });
 
   it('should format a mulitline props', () => {
@@ -187,6 +202,7 @@ describe('formatProp', () => {
 
     expect(formatPropValue).toHaveBeenCalledWith(
       ['a', 'b'],
+      'foo',
       false,
       0,
       defaultOptions
@@ -217,6 +233,12 @@ describe('formatProp', () => {
       isMultilineAttribute: false,
     });
 
-    expect(formatPropValue).toHaveBeenCalledWith('bar', true, 4, options);
+    expect(formatPropValue).toHaveBeenCalledWith(
+      'bar',
+      'foo',
+      true,
+      4,
+      options
+    );
   });
 });

--- a/src/formatter/formatPropValue.js
+++ b/src/formatter/formatPropValue.js
@@ -12,6 +12,7 @@ const escape = (s: string): string => s.replace(/"/g, '&quot;');
 
 const formatPropValue = (
   propValue: any,
+  propName: string,
   inline: boolean,
   lvl: number,
   options: Options
@@ -41,7 +42,7 @@ const formatPropValue = (
   }
 
   if (typeof propValue === 'function') {
-    return `{${formatFunction(propValue, true, lvl, options)}}`;
+    return `{${formatFunction(propValue, propName, true, lvl, options)}}`;
   }
 
   if (isValidElement(propValue)) {
@@ -61,7 +62,13 @@ const formatPropValue = (
   }
 
   if (isPlainObject(propValue) || Array.isArray(propValue)) {
-    return `{${formatComplexDataStructure(propValue, inline, lvl, options)}}`;
+    return `{${formatComplexDataStructure(
+      propValue,
+      propName,
+      inline,
+      lvl,
+      options
+    )}}`;
   }
 
   return `{${String(propValue)}}`;

--- a/src/formatter/formatPropValue.js
+++ b/src/formatter/formatPropValue.js
@@ -41,7 +41,7 @@ const formatPropValue = (
   }
 
   if (typeof propValue === 'function') {
-    return `{${formatFunction(propValue, options)}}`;
+    return `{${formatFunction(propValue, true, lvl, options)}}`;
   }
 
   if (isValidElement(propValue)) {

--- a/src/formatter/formatPropValue.spec.js
+++ b/src/formatter/formatPropValue.spec.js
@@ -20,28 +20,28 @@ describe('formatPropValue', () => {
   });
 
   it('should format an integer prop value', () => {
-    expect(formatPropValue(42, false, 0, {})).toBe('{42}');
+    expect(formatPropValue(42, 'foo', false, 0, {})).toBe('{42}');
   });
 
   it('should escape double quote on prop value of string type', () => {
-    expect(formatPropValue('Hello "Jonh"!', false, 0, {})).toBe(
+    expect(formatPropValue('Hello "Jonh"!', 'foo', false, 0, {})).toBe(
       '"Hello &quot;Jonh&quot;!"'
     );
   });
 
   it('should format a symbol prop value', () => {
-    expect(formatPropValue(Symbol('Foo'), false, 0, {})).toBe(
+    expect(formatPropValue(Symbol('Foo'), 'foo', false, 0, {})).toBe(
       "{Symbol('Foo')}"
     );
 
     // eslint-disable-next-line symbol-description
-    expect(formatPropValue(Symbol(), false, 0, {})).toBe('{Symbol()}');
+    expect(formatPropValue(Symbol(), 'foo', false, 0, {})).toBe('{Symbol()}');
   });
 
   it('should replace a function prop value by a an empty generic function by default', () => {
     const doThings = a => a * 2;
 
-    expect(formatPropValue(doThings, false, 0, {})).toBe(
+    expect(formatPropValue(doThings, 'foo', false, 0, {})).toBe(
       '{function noRefCheck() {}}'
     );
   });
@@ -49,9 +49,9 @@ describe('formatPropValue', () => {
   it('should show the function prop value implementation if "showFunctions" option is true', () => {
     const doThings = a => a * 2;
 
-    expect(formatPropValue(doThings, false, 0, { showFunctions: true })).toBe(
-      '{function doThings(a) {return a * 2;}}'
-    );
+    expect(
+      formatPropValue(doThings, 'foo', false, 0, { showFunctions: true })
+    ).toBe('{function doThings(a) {return a * 2;}}');
   });
 
   it('should format the function prop value with the "functionValue" option', () => {
@@ -64,14 +64,14 @@ describe('formatPropValue', () => {
     };
 
     expect(
-      formatPropValue(doThings, false, 0, {
+      formatPropValue(doThings, 'foo', false, 0, {
         functionValue,
         showFunctions: true,
       })
     ).toBe('{function Myfunction() {}}');
 
     expect(
-      formatPropValue(doThings, false, 0, {
+      formatPropValue(doThings, 'foo', false, 0, {
         functionValue,
         showFunctions: false,
       })
@@ -79,7 +79,7 @@ describe('formatPropValue', () => {
   });
 
   it('should parse and format a react element prop value', () => {
-    expect(formatPropValue(<div />, false, 0, {})).toBe(
+    expect(formatPropValue(<div />, 'foo', false, 0, {})).toBe(
       '{<MockedFormatTreeNodeResult />}'
     );
 
@@ -89,18 +89,18 @@ describe('formatPropValue', () => {
 
   it('should format a date prop value', () => {
     expect(
-      formatPropValue(new Date('2017-01-01T11:00:00.000Z'), false, 0, {})
+      formatPropValue(new Date('2017-01-01T11:00:00.000Z'), 'foo', false, 0, {})
     ).toBe('{new Date("2017-01-01T11:00:00.000Z")}');
   });
 
   it('should format an invalid date prop value', () => {
-    expect(formatPropValue(new Date(NaN), false, 0, {})).toBe(
+    expect(formatPropValue(new Date(NaN), 'foo', false, 0, {})).toBe(
       '{new Date(NaN)}'
     );
   });
 
   it('should format an object prop value', () => {
-    expect(formatPropValue({ foo: 42 }, false, 0, {})).toBe(
+    expect(formatPropValue({ foo: 42 }, 'foo', false, 0, {})).toBe(
       '{*Mocked formatComplexDataStructure result*}'
     );
 
@@ -108,7 +108,7 @@ describe('formatPropValue', () => {
   });
 
   it('should format an array prop value', () => {
-    expect(formatPropValue(['a', 'b', 'c'], false, 0, {})).toBe(
+    expect(formatPropValue(['a', 'b', 'c'], 'foo', false, 0, {})).toBe(
       '{*Mocked formatComplexDataStructure result*}'
     );
 
@@ -116,23 +116,25 @@ describe('formatPropValue', () => {
   });
 
   it('should format a boolean prop value', () => {
-    expect(formatPropValue(true, false, 0, {})).toBe('{true}');
-    expect(formatPropValue(false, false, 0, {})).toBe('{false}');
+    expect(formatPropValue(true, 'foo', false, 0, {})).toBe('{true}');
+    expect(formatPropValue(false, 'foo', false, 0, {})).toBe('{false}');
   });
 
   it('should format null prop value', () => {
-    expect(formatPropValue(null, false, 0, {})).toBe('{null}');
+    expect(formatPropValue(null, 'foo', false, 0, {})).toBe('{null}');
   });
 
   it('should format undefined prop value', () => {
-    expect(formatPropValue(undefined, false, 0, {})).toBe('{undefined}');
+    expect(formatPropValue(undefined, 'foo', false, 0, {})).toBe('{undefined}');
   });
 
   it('should call the ".toString()" method on object instance prop value', () => {
-    expect(formatPropValue(new Set(['a', 'b', 42]), false, 0, {})).toBe(
+    expect(formatPropValue(new Set(['a', 'b', 42]), 'foo', false, 0, {})).toBe(
       '{[object Set]}'
     );
 
-    expect(formatPropValue(new Map(), false, 0, {})).toBe('{[object Map]}');
+    expect(formatPropValue(new Map(), 'foo', false, 0, {})).toBe(
+      '{[object Map]}'
+    );
   });
 });

--- a/src/formatter/formatTreeNode.js
+++ b/src/formatter/formatTreeNode.js
@@ -48,7 +48,7 @@ export default (
   }
 
   if (node.type === 'function') {
-    return `{${formatFunction(node.value, options)}}`;
+    return `{${formatFunction(node.value, inline, lvl, options)}}`;
   }
 
   if (node.type === 'ReactElement') {

--- a/src/formatter/formatTreeNode.js
+++ b/src/formatter/formatTreeNode.js
@@ -48,7 +48,7 @@ export default (
   }
 
   if (node.type === 'function') {
-    return `{${formatFunction(node.value, inline, lvl, options)}}`;
+    return `{${formatFunction(node.value, 'children', inline, lvl, options)}}`;
   }
 
   if (node.type === 'ReactElement') {

--- a/src/formatter/formatTreeNode.js
+++ b/src/formatter/formatTreeNode.js
@@ -2,6 +2,7 @@
 
 import formatReactElementNode from './formatReactElementNode';
 import formatReactFragmentNode from './formatReactFragmentNode';
+import formatFunction from './formatFunction';
 import type { Options } from './../options';
 import type { TreeNode } from './../tree';
 
@@ -44,6 +45,10 @@ export default (
     return node.value
       ? `${preserveTrailingSpace(escape(String(node.value)))}`
       : '';
+  }
+
+  if (node.type === 'function') {
+    return `{${formatFunction(node.value, options)}}`;
   }
 
   if (node.type === 'ReactElement') {

--- a/src/formatter/formatTreeNode.spec.js
+++ b/src/formatter/formatTreeNode.spec.js
@@ -19,6 +19,25 @@ describe('formatTreeNode', () => {
     );
   });
 
+  it('should format function tree node', () => {
+    function fun(a) {
+      return a + 1;
+    }
+    expect(
+      formatTreeNode(
+        {
+          type: 'function',
+          value: fun,
+        },
+        true,
+        0,
+        {
+          showFunctions: true,
+        }
+      )
+    ).toBe('{function fun(a) {return a + 1;}}');
+  });
+
   it('should format react element tree node', () => {
     expect(
       formatTreeNode(

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -903,6 +903,29 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual(`<div fn={function fn() {return 'value';}} />`);
   });
 
+  it('should ident deeply nested multi-line functions correctly', () => {
+    /* eslint-disable arrow-body-style */
+    const fn = () => {
+      return 'value';
+    };
+
+    expect(
+      reactElementToJSXString(
+        <div fn={fn}>
+          <div fn={fn}>
+            <div fn={fn} />
+          </div>
+        </div>,
+        {
+          showFunctions: true,
+          functionValue: preserveFunctionLineBreak,
+        }
+      )
+    ).toEqual(
+      "<div\n  fn={function fn() {\n      return 'value';\n    }}\n>\n  <div\n    fn={function fn() {\n        return 'value';\n      }}\n  >\n    <div\n      fn={function fn() {\n          return 'value';\n        }}\n     />\n  </div>\n</div>"
+    );
+  });
+
   it('should expose the multiline "functionValue" formatter', () => {
     /* eslint-disable arrow-body-style */
     const fn = () => {

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -1136,6 +1136,17 @@ describe('reactElementToJSXString(ReactElement)', () => {
     ).toEqual(`<div render={<><div /><div /></>} />`);
   });
 
+  it('reactElementToJSXString(<div>{() => <div />}</div>)', () => {
+    const renderJSX = jsx =>
+      reactElementToJSXString(jsx, {
+        showFunctions: (_, prop) => prop === 'children',
+        functionValue: fn => `() => ${renderJSX(fn())}`,
+      });
+    expect(renderJSX(<div>{() => <div />}</div>)).toEqual(
+      `<div>\n  {() => <div />}\n</div>`
+    );
+  });
+
   it('should not cause recursive loop when prop object contains an element', () => {
     const Test = () => <div>Test</div>;
 

--- a/src/options.js
+++ b/src/options.js
@@ -5,8 +5,8 @@ import * as React from 'react';
 export type Options = {|
   filterProps: string[],
   showDefaultProps: boolean,
-  showFunctions: boolean,
-  functionValue: Function,
+  showFunctions: boolean | ((fn: Function, prop: string) => boolean),
+  functionValue: (fn: Function, prop: string) => Function | string,
   tabStop: number,
   useBooleanShorthandSyntax: boolean,
   useFragmentShortSyntax: boolean,

--- a/src/parser/parseReactElement.js
+++ b/src/parser/parseReactElement.js
@@ -5,6 +5,7 @@ import type { Options } from './../options';
 import {
   createStringTreeNode,
   createNumberTreeNode,
+  createFunctionTreeNode,
   createReactElementTreeNode,
   createReactFragmentTreeNode,
 } from './../tree';
@@ -67,9 +68,15 @@ const parseReactElement = (
   }
 
   const defaultProps = filterProps(element.type.defaultProps || {}, noChildren);
-  const childrens = React.Children.toArray(element.props.children)
-    .filter(onlyMeaningfulChildren)
-    .map(child => parseReactElement(child, options));
+
+  let childrens;
+  if (typeof element.props.children === 'function') {
+    childrens = [createFunctionTreeNode(element.props.children)];
+  } else {
+    childrens = React.Children.toArray(element.props.children)
+      .filter(onlyMeaningfulChildren)
+      .map(child => parseReactElement(child, options));
+  }
 
   if (supportFragment && element.type === Fragment) {
     return createReactFragmentTreeNode(key, childrens);

--- a/src/parser/parseReactElement.spec.js
+++ b/src/parser/parseReactElement.spec.js
@@ -182,4 +182,25 @@ describe('parseReactElement', () => {
       ],
     });
   });
+
+  it('should parse children function', () => {
+    const RenderProp = ({ children }) => children({});
+    const fun = () => <div />;
+    expect(
+      parseReactElement(<RenderProp key="foo">{fun}</RenderProp>, options)
+    ).toEqual({
+      type: 'ReactElement',
+      displayName: 'RenderProp',
+      defaultProps: {},
+      props: {
+        key: 'foo',
+      },
+      childrens: [
+        {
+          type: 'function',
+          value: fun,
+        },
+      ],
+    });
+  });
 });

--- a/src/tree.js
+++ b/src/tree.js
@@ -16,6 +16,11 @@ export type NumberTreeNode = {|
   value: number,
 |};
 
+export type FunctionTreeNode = {|
+  type: 'function',
+  value: Function,
+|};
+
 export type ReactElementTreeNode = {|
   type: 'ReactElement',
   displayName: string,
@@ -33,6 +38,7 @@ export type ReactFragmentTreeNode = {|
 export type TreeNode =
   | StringTreeNode
   | NumberTreeNode
+  | FunctionTreeNode
   | ReactElementTreeNode
   | ReactFragmentTreeNode;
 
@@ -43,6 +49,11 @@ export const createStringTreeNode = (value: string): StringTreeNode => ({
 
 export const createNumberTreeNode = (value: number): NumberTreeNode => ({
   type: 'number',
+  value,
+});
+
+export const createFunctionTreeNode = (value: Function): FunctionTreeNode => ({
+  type: 'function',
   value,
 });
 

--- a/src/tree.spec.js
+++ b/src/tree.spec.js
@@ -3,6 +3,7 @@
 import {
   createStringTreeNode,
   createNumberTreeNode,
+  createFunctionTreeNode,
   createReactElementTreeNode,
   createReactFragmentTreeNode,
 } from './tree';
@@ -21,6 +22,16 @@ describe('createNumberTreeNode', () => {
     expect(createNumberTreeNode(42)).toEqual({
       type: 'number',
       value: 42,
+    });
+  });
+});
+
+describe('createFunctionTreeNode', () => {
+  it('generate a number typed node payload', () => {
+    const fun = () => null;
+    expect(createFunctionTreeNode(fun)).toEqual({
+      type: 'function',
+      value: fun,
     });
   });
 });


### PR DESCRIPTION
There was another attempt to fix this (#338) which I suppose wasn't merged because the author didn't address an issue raised about calling function children in order to print them.

This is fine for pure functions that return react elements, but you can't guarantee that function children always behave like this, so this could cause problems for users who have unconventional function children.

Another approach could be printing the function's source, but since sources are subject to transpilation by babel before runtime, just printing the function's body wouldn't yield JSX.
Or you could use source maps to print the original code instead, but printing JSX code as string has its own limitations as the output isn't parsed and formatted by this library.

As each of these methods have their own trade-offs, I've decided to go for a less opinionated solution and leave this decision up to the library user. Functions as children will work the same as if they were any other prop, users can choose how to format them using `functionValue` and `showFunctions` options.
Additionally, I've altered both these options to provide more granularity on if and how each function prints since users may want to handle render props differently than other function props.


What I did:
- Fixed indentation of deeply nested multi-line functions
- Parse function children (typeof children === 'function', not otherwise)
- Allow more granularity for rendering of functions
  -  Added `prop` param to `functionValue` option
  -  Added `showFunctions` function option to filter prop by prop