### PR TITLE
fix: handle circular references in `sortObject`

### DIFF
--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export default function sortObject(value: any): any {
+export default function sortObject(value: any, seen = new Set()): any {
   // return non-object value as is
   if (value === null || typeof value !== 'object') {
     return value;
@@ -11,9 +11,12 @@ export default function sortObject(value: any): any {
     return value;
   }
 
+  if (seen.has(value)) return '[Circular]';
+  seen.add(value);
+
   // make a copy of array with each item passed through sortObject()
   if (Array.isArray(value)) {
-    return value.map(sortObject);
+    return value.map(value => sortObject(value, seen));
   }
 
   // make a copy of object with key sorted
@@ -28,7 +31,7 @@ export default function sortObject(value: any): any {
         result[key] = '[Circular]';
       } else {
         // eslint-disable-next-line no-param-reassign
-        result[key] = sortObject(value[key]);
+        result[key] = sortObject(value[key], seen);
       }
       return result;
     }, {});

--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-export default function sortObject(value: any, seen = new Set()): any {
+export default function sortObject(value: any, seen = []): any {
   // return non-object value as is
   if (value === null || typeof value !== 'object') {
     return value;
@@ -11,22 +11,25 @@ export default function sortObject(value: any, seen = new Set()): any {
     return value;
   }
 
-  if (seen.has(value)) return '[Circular]';
-  seen.add(value);
+  if (seen.includes(value)) return '[Circular]';
+  seen.push(value);
 
-  // make a copy of array with each item passed through sortObject()
   if (Array.isArray(value)) {
-    return value.map(value => sortObject(value, seen));
+    // make a copy of array with each item passed through sortObject()
+    value = value.map(value => sortObject(value, seen));
+  } else {
+    // make a copy of object with key sorted
+    value = Object.keys(value)
+      .sort()
+      .reduce((result, key) => {
+        if (key !== '_owner') {
+          // eslint-disable-next-line no-param-reassign
+          result[key] = sortObject(value[key], seen);
+        }
+        return result;
+      }, {});
   }
 
-  // make a copy of object with key sorted
-  return Object.keys(value)
-    .sort()
-    .reduce((result, key) => {
-      if (key !== '_owner') {
-        // eslint-disable-next-line no-param-reassign
-        result[key] = sortObject(value[key], seen);
-      }
-      return result;
-    }, {});
+  seen.pop();
+  return value;
 }

--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -23,13 +23,7 @@ export default function sortObject(value: any, seen = new Set()): any {
   return Object.keys(value)
     .sort()
     .reduce((result, key) => {
-      if (key === '_owner') {
-        return result;
-      }
-      if (key === 'current') {
-        // eslint-disable-next-line no-param-reassign
-        result[key] = '[Circular]';
-      } else {
+      if (key !== '_owner') {
         // eslint-disable-next-line no-param-reassign
         result[key] = sortObject(value[key], seen);
       }

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -42,4 +42,11 @@ describe('sortObject', () => {
       c: date,
     });
   });
+
+  it('should detect circular references', () => {
+    const fixture = { a: {} };
+    fixture.a.b = fixture;
+
+    expect(sortObject(fixture)).toMatchInlineSnapshot();
+  });
 });

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -46,6 +46,7 @@ describe('sortObject', () => {
   it('should detect circular references', () => {
     const fixture = { a: {} };
     fixture.a.b = fixture;
+    fixture.array = [fixture.a];
 
     expect(sortObject(fixture)).toMatchInlineSnapshot(`
       Object {

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -47,6 +47,12 @@ describe('sortObject', () => {
     const fixture = { a: {} };
     fixture.a.b = fixture;
 
-    expect(sortObject(fixture)).toMatchInlineSnapshot();
+    expect(sortObject(fixture)).toMatchInlineSnapshot(`
+      Object {
+        "a": Object {
+          "b": "[Circular]",
+        },
+      }
+    `);
   });
 });

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -53,6 +53,11 @@ describe('sortObject', () => {
         "a": Object {
           "b": "[Circular]",
         },
+        "array": Array [
+          Object {
+            "b": "[Circular]",
+          },
+        ],
       }
     `);
   });


### PR DESCRIPTION
Instead of handling circular references for React refs only, handle them for everything.

Published under [`@alloc/react-element-to-string`](https://www.npmjs.com/package/@alloc/react-element-to-string) for anyone who needs this change now.