### PR TITLE
fix: improve perf by not stringifying React elements within `prettyPrint`

### DIFF
--- a/src/formatter/formatComplexDataStructure.js
+++ b/src/formatter/formatComplexDataStructure.js
@@ -18,6 +18,13 @@ export default (
   const normalizedValue = sortObject(value);
 
   const stringifiedValue = prettyPrint(normalizedValue, {
+    // `prettyPrint` first calls `filter`, then stringifies the value
+    // and only after that calls `transform` (with stringified value as 3rd argument - `originalResult`)
+    // since we don't care about `originalResult` for valid React elements and functions
+    // we can "skip" stringifying step by filtering out all of the keys using custom `filter`
+    // this acts as a perf optimization since React elements can hold fiber data and it can be a deeply nested structure
+    filter: currentValue =>
+      !isValidElement(currentValue) && typeof currentValue !== 'function',
     transform: (currentObj, prop, originalResult) => {
       const currentValue = currentObj[prop];
 


### PR DESCRIPTION
This has actually **fixed** an issue for me because `prettyPrint` was acting like an infinite loop. This is slightly odd because it implements `seen` tracking and shouldn't be prone to circular structures issues. What is even odder - after I've fixed this locally with `patch-package`, verified the fix, and reverted back so I could create a reduced test case for `react-element-to-jsx-string` then it stopped happening.

What I know is that it was looping through fiber data and its `return` property - which happened through a React element that was passed to `formatComplexDataStructure`. I'm not a fan of introducing code without knowing the root cause behind a problem and having a test case for the issue so I would totally understand if you wouldn't like to merge this in just yet. However, at the very least - this is a perf optimization (explained in the added comment) and for those things we usually don't write tests anyway so this could still be accepted "as is".
