### PR TITLE
Fix recursion with react elements

### DIFF
--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -7,12 +7,8 @@ function safeSortObject(value: any, seen: WeakSet<any>): any {
     return value;
   }
 
-  // return date, regexp and react element values as is
-  if (
-    value instanceof Date ||
-    value instanceof RegExp ||
-    React.isValidElement(value)
-  ) {
+  // return date and regexp values as is
+  if (value instanceof Date || value instanceof RegExp) {
     return value;
   }
 

--- a/src/formatter/sortObject.js
+++ b/src/formatter/sortObject.js
@@ -12,6 +12,13 @@ function safeSortObject(value: any, seen: WeakSet<any>): any {
     return value;
   }
 
+  // return react element as is but remove _owner key because it can lead to recursion
+  if (React.isValidElement(value)) {
+    const copyObj = { ...value };
+    delete copyObj._owner;
+    return copyObj;
+  }
+
   seen.add(value);
 
   // make a copy of array with each item passed through the sorting algorithm
@@ -23,9 +30,6 @@ function safeSortObject(value: any, seen: WeakSet<any>): any {
   return Object.keys(value)
     .sort()
     .reduce((result, key) => {
-      if (key === '_owner') {
-        return result;
-      }
       if (key === 'current' || seen.has(value[key])) {
         // eslint-disable-next-line no-param-reassign
         result[key] = '[Circular]';

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -1,5 +1,6 @@
 /* @flow */
 
+import React from 'react';
 import sortObject from './sortObject';
 
 describe('sortObject', () => {
@@ -41,5 +42,25 @@ describe('sortObject', () => {
       b: regexp,
       c: date,
     });
+  });
+
+  it('should remove _owner key from react elements', () => {
+    const fixture = {
+      _owner: "_owner that doesn't belong to react element",
+      component: <div />,
+    };
+
+    expect(JSON.stringify(sortObject(fixture))).toEqual(
+      JSON.stringify({
+        _owner: "_owner that doesn't belong to react element",
+        component: {
+          $$typeof: Symbol('react.transitional.element'),
+          type: 'div',
+          key: null,
+          props: {},
+          _store: {},
+        },
+      })
+    );
   });
 });

--- a/src/formatter/sortObject.spec.js
+++ b/src/formatter/sortObject.spec.js
@@ -44,23 +44,48 @@ describe('sortObject', () => {
     });
   });
 
-  it('should remove _owner key from react elements', () => {
-    const fixture = {
-      _owner: "_owner that doesn't belong to react element",
-      component: <div />,
-    };
-
-    expect(JSON.stringify(sortObject(fixture))).toEqual(
-      JSON.stringify({
+  describe('_owner key', () => {
+    it('should preserve the _owner key for objects that are not react elements', () => {
+      const fixture = {
         _owner: "_owner that doesn't belong to react element",
-        component: {
-          $$typeof: Symbol('react.transitional.element'),
-          type: 'div',
-          key: null,
-          props: {},
-          _store: {},
-        },
-      })
-    );
+        foo: 'bar',
+      };
+
+      expect(JSON.stringify(sortObject(fixture))).toEqual(
+        JSON.stringify({
+          _owner: "_owner that doesn't belong to react element",
+          foo: 'bar',
+        })
+      );
+    });
+
+    it('should remove the _owner key from top level react element', () => {
+      const fixture = {
+        reactElement: (
+          <div>
+            <span></span>
+          </div>
+        ),
+      };
+
+      expect(JSON.stringify(sortObject(fixture))).toEqual(
+        JSON.stringify({
+          reactElement: {
+            type: 'div',
+            key: null,
+            props: {
+              children: {
+                type: 'span',
+                key: null,
+                props: {},
+                _owner: null,
+                _store: {},
+              },
+            },
+            _store: {},
+          },
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
It fixes https://github.com/algolia/react-element-to-jsx-string/issues/681

The bug was introduced in https://github.com/algolia/react-element-to-jsx-string/pull/619.

It's not a first time since we encounter this issue, see https://github.com/algolia/react-element-to-jsx-string/issues/307 and especially https://github.com/algolia/react-element-to-jsx-string/pull/312#issuecomment-427134793. 

I faced it in storybook and managed to reproduce it using this story:

```typescript
import { Meta, Story } from "@storybook/react";
import { Buttons, ButtonsProps } from "./Buttons";

export default {
  title: "Components/Buttons",
  component: Buttons,
} as Meta<ButtonsProps>;

export const Default: Story<ButtonsProps> = ({}: ButtonsProps) => (
  <div
    buttons={[
      {
        foo: "bar",
        jsx: <div key="1">Button in array</div>, // this leads to OOM
      },
    ]}
  />
);
```

but couldn't write test case for it. I tried to reproduce it using code snippet from https://github.com/algolia/react-element-to-jsx-string/pull/312#issuecomment-427134793 with latest react and react-element-to-jsx-string but couldn't for some reasons.

So this is why I decided to add test directly to `src/formatter/sortObject.spec.js`

It also should fix https://github.com/storybookjs/storybook/issues/16827.

I suggest to backport it to v15 because people mostly use react 18 right now:
![image](https://github.com/user-attachments/assets/d5e7ab25-651a-4cd9-9d62-9e611cc0782d)